### PR TITLE
[#2] 약관 세부 api 파라미터 추가구현

### DIFF
--- a/src/main/java/com/flab/s_market/domains/term/controller/TermController.java
+++ b/src/main/java/com/flab/s_market/domains/term/controller/TermController.java
@@ -8,6 +8,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
@@ -22,8 +23,11 @@ public class TermController {
         return ApiResponse.createSuccess(termService.getAllTerms());
     }
 
-    @GetMapping("/terms/detail") // term_id, version
-    public ApiResponse<DetailTermDTO> getDetailTerms(){
-        return ApiResponse.createSuccess(termService.getDetailTerms());
+    @GetMapping("/terms/detail")
+    public ApiResponse<DetailTermDTO> getDetailTerms(
+        @RequestParam(name = "termId") Long termId,
+        @RequestParam(name = "version") Integer version
+    ){
+        return ApiResponse.createSuccess(termService.getDetailTerms(termId, version));
     }
 }

--- a/src/main/java/com/flab/s_market/domains/term/repository/SubTermCustomRepository.java
+++ b/src/main/java/com/flab/s_market/domains/term/repository/SubTermCustomRepository.java
@@ -3,5 +3,5 @@ package com.flab.s_market.domains.term.repository;
 import com.flab.s_market.domains.term.dto.response.DetailTermDTO;
 
 public interface SubTermCustomRepository {
-    public DetailTermDTO findByVersionAndUrl();
+    public DetailTermDTO findByTermIdAndVersion(Long termId, Integer version);
 }

--- a/src/main/java/com/flab/s_market/domains/term/repository/SubTermCustomRepositoryImpl.java
+++ b/src/main/java/com/flab/s_market/domains/term/repository/SubTermCustomRepositoryImpl.java
@@ -15,7 +15,7 @@ public class SubTermCustomRepositoryImpl implements SubTermCustomRepository{
     }
 
     @Override
-    public DetailTermDTO findByVersionAndUrl() {
+    public DetailTermDTO findByTermIdAndVersion(Long termId, Integer version) {
         QSubTerm subTerm = QSubTerm.subTerm;
 
         return queryFactory
@@ -25,8 +25,7 @@ public class SubTermCustomRepositoryImpl implements SubTermCustomRepository{
                 subTerm.term.title
             ))
             .from(subTerm)
-            .orderBy(subTerm.id.version.desc())
-            .limit(1)
+            .where(subTerm.id.termId.eq(termId), subTerm.id.version.eq(version))
             .fetchOne();
     }
 }

--- a/src/main/java/com/flab/s_market/domains/term/service/TermService.java
+++ b/src/main/java/com/flab/s_market/domains/term/service/TermService.java
@@ -42,7 +42,8 @@ public class TermService {
         return AllTermResponseDTO.convertTermsResponseDTOToAllTermResponseDTO(mainDto, additionalDto);
     }
 
-    public DetailTermDTO getDetailTerms() {
-        return subTermRepository.findByVersionAndUrl();
+    public DetailTermDTO getDetailTerms(Long termId, Integer version) {
+
+        return subTermRepository.findByTermIdAndVersion(termId, version);
     }
 }


### PR DESCRIPTION
## #️⃣ 연관된 이슈

- #2 

## 📝 구현 기능 명세

- 약관 세부 조회를 위한 termId와 version을 요청 파라미터에 담아 요청을 받아 인덱스 활용
- QueryDSL에서 where 조건절에 파라미터 추가

### 📷 스크린샷 (선택)

❌

## 💬 어려웠던 점

❌
