### PR TITLE
[#5] 이메일 인증코드 확인 구현 (#5)

### DIFF
--- a/src/main/java/com/flab/s_market/common/config/AES128Config.java
+++ b/src/main/java/com/flab/s_market/common/config/AES128Config.java
@@ -1,0 +1,66 @@
+package com.flab.s_market.common.config;
+
+import com.flab.s_market.common.exception.CustomException;
+import com.flab.s_market.common.exception.ErrorCode;
+import jakarta.annotation.PostConstruct;
+import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
+import java.security.NoSuchAlgorithmException;
+import java.security.SecureRandom;
+import java.util.Arrays;
+import java.util.Base64;
+import javax.crypto.Cipher;
+import javax.crypto.NoSuchPaddingException;
+import javax.crypto.spec.IvParameterSpec;
+import javax.crypto.spec.SecretKeySpec;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+@Component
+public class AES128Config {
+    private static final Charset ENCODING_TYPE = StandardCharsets.UTF_8;
+    private static final String INSTANCE_TYPE = "AES/CBC/PKCS5Padding";
+    private static final int AES_KEY_SIZE = 16;
+
+    @Value("${aes.secret-key}")
+    private String secretKey;
+    private IvParameterSpec ivParameterSpec;
+    private SecretKeySpec secretKeySpec;
+    private Cipher cipher;
+
+    @PostConstruct
+    public void init() throws NoSuchPaddingException, NoSuchAlgorithmException {
+        SecureRandom secureRandom = new SecureRandom();
+        byte[] iv = new byte[16];   // 16bytes = 128bits
+        secureRandom.nextBytes(iv); // 16바이트 크기의 난수 바이트 배열 생성
+        ivParameterSpec = new IvParameterSpec(iv);
+
+        byte[] keyBytes = secretKey.getBytes(ENCODING_TYPE);
+        keyBytes = Arrays.copyOf(keyBytes, AES_KEY_SIZE);
+        secretKeySpec = new SecretKeySpec(keyBytes, "AES");
+        cipher = Cipher.getInstance(INSTANCE_TYPE);
+
+    }
+
+    // AES 암호화
+    public String encryptAes(String plaintext){
+        try {
+            cipher.init(Cipher.ENCRYPT_MODE, secretKeySpec, ivParameterSpec);
+            byte[] encryted = cipher.doFinal(plaintext.getBytes(ENCODING_TYPE)); // 데이터 암호화
+            return new String(Base64.getEncoder().encode(encryted), ENCODING_TYPE); // 문자열 인코딩 반환
+        } catch (Exception e) {
+            throw new CustomException(ErrorCode.ENCRYPTION_FAILED);
+        }
+    }
+
+    // AES 복호화
+    public String decryptAes(String plaintext) {
+        try {
+            cipher.init(Cipher.DECRYPT_MODE, secretKeySpec, ivParameterSpec);
+            byte[] decoded = Base64.getDecoder().decode(plaintext.getBytes(ENCODING_TYPE));
+            return new String(cipher.doFinal(decoded), ENCODING_TYPE); // 데이터 복호화, 인코딩 반환
+        } catch (Exception e) {
+            throw new CustomException(ErrorCode.DECRYPTION_FAILED);
+        }
+    }
+}

--- a/src/main/java/com/flab/s_market/common/exception/ErrorCode.java
+++ b/src/main/java/com/flab/s_market/common/exception/ErrorCode.java
@@ -11,7 +11,9 @@ public enum ErrorCode {
     NOT_VALID_EMAIL_CODE("ACCOUNT-002", "인증코드가 틀립니다. 이메일을 확인해주세요.", HttpStatus.NOT_FOUND),
     NOT_VALID_PASSWORD("ACCOUNT-03", "비밀번호와 재확인 비밀번호가 다릅니다. 비밀번호를 다시 확인해주세요.", HttpStatus.BAD_REQUEST),
     NOT_EXIST_TERM("ACCOUNT-04", "존재하지 않는 약관입니다. 약관 버전 또는 약관명을 다시 확인해주세요.", HttpStatus.NOT_FOUND),
-    MAIL_SYSTEM_ERROR("ACCOUNT-05", "이메일 시스템 에러가 발생했습니다. 발송 이메일을 다시 확인해주세요.", HttpStatus.INTERNAL_SERVER_ERROR);
+    MAIL_SYSTEM_ERROR("ACCOUNT-05", "이메일 시스템 에러가 발생했습니다. 발송 이메일을 다시 확인해주세요.", HttpStatus.INTERNAL_SERVER_ERROR),
+    ENCRYPTION_FAILED("ACCOUNT-06", "이메일 암호화에 실패하였습니다. 다시 시도해주세요.", HttpStatus.INTERNAL_SERVER_ERROR),
+    DECRYPTION_FAILED("ACCOUNT-07", "이메일키 복호화에 실패하였습니다. 다시 시도해주세요.", HttpStatus.INTERNAL_SERVER_ERROR);
 
     private final String code;
     private final String message;

--- a/src/main/java/com/flab/s_market/domains/user/controller/v1/UserController.java
+++ b/src/main/java/com/flab/s_market/domains/user/controller/v1/UserController.java
@@ -1,8 +1,6 @@
 package com.flab.s_market.domains.user.controller.v1;
 
 import com.flab.s_market.common.entity.ApiResponse;
-import com.flab.s_market.common.exception.CustomException;
-import com.flab.s_market.common.exception.ErrorCode;
 import com.flab.s_market.domains.user.dto.request.EmailCodeDTO;
 import com.flab.s_market.domains.user.dto.request.EmailDTO;
 import com.flab.s_market.domains.user.dto.request.JoinInfoDTO;
@@ -37,12 +35,8 @@ public class UserController {
         emailService.sendEmail(emailDTO.email());
     }
     @PostMapping("/verifyCode")
-    // 암호키 주기 (대칭키)AES-2048, 1024
-    public ApiResponse<String> verifyCode(@RequestBody EmailCodeDTO dto) {
-        if(emailService.verifyEmailCode(dto.email(), dto.code())){ //
-            return ApiResponse.createSuccess(dto.email()); // 암호화 값을 던지기
-        }
-        throw new CustomException(ErrorCode.NOT_VALID_EMAIL_CODE);
+    public ApiResponse<String> verifyCode(@RequestBody EmailCodeDTO dto){
+        return ApiResponse.createSuccess(emailService.verifyEmailCode(dto));
     }
 
     @PostMapping("/join")

--- a/src/main/java/com/flab/s_market/domains/user/service/EmailService.java
+++ b/src/main/java/com/flab/s_market/domains/user/service/EmailService.java
@@ -1,8 +1,10 @@
 package com.flab.s_market.domains.user.service;
 
+import com.flab.s_market.common.config.AES128Config;
 import com.flab.s_market.common.exception.CustomException;
 import com.flab.s_market.common.exception.ErrorCode;
 import com.flab.s_market.common.util.RedisUtil;
+import com.flab.s_market.domains.user.dto.request.EmailCodeDTO;
 import jakarta.mail.MessagingException;
 import jakarta.mail.internet.MimeMessage;
 import java.security.MessageDigest;
@@ -27,6 +29,7 @@ import org.thymeleaf.templateresolver.ClassLoaderTemplateResolver;
 public class EmailService {
     private final JavaMailSender mailSender;
     private final RedisUtil redisUtil;
+    private final AES128Config aes128Config;
     private Logger log = LoggerFactory.getLogger(EmailService.class);
 
     @Value("${spring.mail.username}")
@@ -95,13 +98,22 @@ public class EmailService {
     }
 
     // 코드 검증
-    public Boolean verifyEmailCode(String email, String code) {
-        String codeFoundByEmail = redisUtil.getData(email);
+    public String verifyEmailCode(EmailCodeDTO dto){
+        String email = dto.email();
+        String code = dto.code();
+        String codeFoundByEmail = redisUtil.getData(dto.email());
         System.out.println(codeFoundByEmail);
         if (codeFoundByEmail == null) {
-            return false; // 예외던지기
+            throw new CustomException(ErrorCode.NOT_VALID_EMAIL_CODE,
+                Map.of("email", email, "emailCode", code), log::info);
         }
-        return codeFoundByEmail.equals(code); // 일치하지않으면 예외던지기
+        redisUtil.deleteData(email);
+        String emailKey = aes128Config.encryptAes(email);
+        redisUtil.setDataExpire(email, emailKey, 60*30L);
+
+        log.info("enc = {}", emailKey);
+
+        return emailKey;
     }
 
     public String makeMemberId(String email) throws NoSuchAlgorithmException {

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -41,3 +41,6 @@ spring:
 server:
   address: ${SERVER_HOST}
   port: ${SERVER_PORT}
+
+aes:
+  secret-key : ${AES_SECRET_KEY}

--- a/src/test/java/com/flab/s_market/EmailTest.java
+++ b/src/test/java/com/flab/s_market/EmailTest.java
@@ -4,18 +4,31 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import com.flab.s_market.common.config.AES128Config;
 import com.flab.s_market.common.util.RedisUtil;
+import java.security.InvalidAlgorithmParameterException;
+import java.security.InvalidKeyException;
+import javax.crypto.BadPaddingException;
+import javax.crypto.IllegalBlockSizeException;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 
 @ExtendWith(SpringExtension.class)
 @SpringBootTest
+
 public class EmailTest {
     @Autowired
     private RedisUtil redisUtil;
+
+    @Autowired
+    private AES128Config aes128Config;
+    private Logger log = LoggerFactory.getLogger(this.getClass().getSimpleName());
 
     @Test
     public void redisTest(){
@@ -27,5 +40,16 @@ public class EmailTest {
         assertTrue(redisUtil.existData("ghenrhkwk88@gmail.com"));
         assertFalse(redisUtil.existData("ghenrhkwk88@test.com"));
         assertEquals(redisUtil.getData(email), code);
+    }
+
+    @Test
+    @DisplayName("Aes128 암호화가 잘 되는지 확인 테스트")
+    public void aes128Test()
+        throws InvalidAlgorithmParameterException, InvalidKeyException, IllegalBlockSizeException, BadPaddingException {
+        String text = "this is test";
+        String enc = aes128Config.encryptAes(text);
+        String dec = aes128Config.decryptAes(enc);
+        log.info("enc = {}", enc);
+        log.info("dec = {}", dec);
     }
 }


### PR DESCRIPTION
## #️⃣ 연관된 이슈

- #5 

## 📝 구현 기능 명세

- AES 128로 이메일 인증키를 발송하는 것으로 수정
- AES 128로 암복호화를 하며 이메일-인증코드 대신 이메일-이메일키를 저장하도록 추가

### 📷 스크린샷 (선택)

❌

## 💬 어려웠던 점

❌
