### PR TITLE
[#2] 약관 상세 조회 api 구현

### DIFF
--- a/schema.sql
+++ b/schema.sql
@@ -42,7 +42,7 @@ CREATE TABLE `user_sub_term` (
     `user_id`	BIGINT	NOT NULL,
     `term_id`	BIGINT	NOT NULL,
     `version`	INTEGER	NOT NULL COMMENT '약관 버전',
-    `agree_date`	DATETIME	NOT NULL COMMENT'동의한 날짜',
+    `agree`	BIT	NOT NULL COMMENT '동의 여부',
     `created_at`	DATETIME	NOT NULL,
     `modified_at`	DATETIME	NOT NULL,
     primary key (user_id, term_id, version)

--- a/src/main/java/com/flab/s_market/common/entity/ApiResponse.java
+++ b/src/main/java/com/flab/s_market/common/entity/ApiResponse.java
@@ -28,6 +28,10 @@ public class ApiResponse <T>{
         return new ApiResponse<>(e.getErrorCode().getCode(), e.getMessage());
     }
 
+    public static ApiResponse<?> createFail(final Exception e){
+        return new ApiResponse<>(VALID_FAIL_CODE, e.getMessage());
+    }
+
     public static ApiResponse<?> createFailWithBindingResult(final String errorMessage){
         return new ApiResponse<>(VALID_FAIL_CODE, errorMessage);
     }

--- a/src/main/java/com/flab/s_market/common/exception/CustomException.java
+++ b/src/main/java/com/flab/s_market/common/exception/CustomException.java
@@ -3,21 +3,25 @@ package com.flab.s_market.common.exception;
 import java.util.Map;
 import java.util.function.Consumer;
 import lombok.Getter;
-import lombok.RequiredArgsConstructor;
 
 @Getter
-@RequiredArgsConstructor
 public class CustomException extends RuntimeException{
 
     private final ErrorCode errorCode;
-    private Map<String, Object> parameters;
-    private Consumer<String> logMethod;
+    private final Map<String, Object> parameters;
+    private final Consumer<String> logMethod;
+    private final Exception exception;
+    // ex. 외부 라이브러리에서 i/o exception 발생함 -> customException으로 예외 던짐 -> 원본 exception 추가해서 던져줌
     public String getMessage(){
         return errorCode.getMessage();
     }
     public CustomException(ErrorCode errorCode, Map<String, Object> parameters, Consumer<String> logMethod){
+        this(errorCode, parameters, logMethod, null);
+    }
+    public CustomException(ErrorCode errorCode, Map<String, Object> parameters, Consumer<String> logMethod, Exception exception){
         this.errorCode = errorCode;
         this.parameters = parameters;
         this.logMethod = logMethod;
+        this.exception = exception;
     }
 }

--- a/src/main/java/com/flab/s_market/common/exception/ErrorCode.java
+++ b/src/main/java/com/flab/s_market/common/exception/ErrorCode.java
@@ -14,7 +14,8 @@ public enum ErrorCode {
     MAIL_SYSTEM_ERROR("ACCOUNT-05", "이메일 시스템 에러가 발생했습니다. 발송 이메일을 다시 확인해주세요.", HttpStatus.INTERNAL_SERVER_ERROR),
     ENCRYPTION_FAILED("ACCOUNT-06", "이메일 암호화에 실패하였습니다. 다시 시도해주세요.", HttpStatus.INTERNAL_SERVER_ERROR),
     DECRYPTION_FAILED("ACCOUNT-07", "이메일키 복호화에 실패하였습니다. 다시 시도해주세요.", HttpStatus.INTERNAL_SERVER_ERROR),
-    NOT_ALL_AGREED_REQUIRED_TERMS("ACCOUNT-08", "필수 약관에 모두 동의해야합니다.", HttpStatus.BAD_REQUEST);
+    NOT_ALL_AGREED_REQUIRED_TERMS("ACCOUNT-08", "필수 약관에 모두 동의해야합니다.", HttpStatus.BAD_REQUEST),
+    NOT_PASSED_FIVE_MINUTES("ACCOUNT-09", "이메일에 인증코드를 발송한 지 5분이 지나지 않았습니다. 이메일을 확인해주세요.", HttpStatus.NOT_FOUND);
 
     private final String code;
     private final String message;

--- a/src/main/java/com/flab/s_market/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/flab/s_market/common/exception/GlobalExceptionHandler.java
@@ -2,28 +2,45 @@ package com.flab.s_market.common.exception;
 
 import com.flab.s_market.common.entity.ApiResponse;
 import jakarta.validation.ConstraintViolationException;
-import lombok.extern.slf4j.Slf4j;
+import java.util.Arrays;
+import java.util.Map;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.core.annotation.Order;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
-@Slf4j
 @RestControllerAdvice
 public class GlobalExceptionHandler {
+    private Logger log = LoggerFactory.getLogger(GlobalExceptionHandler.class);
+    @Order(1)
     @ExceptionHandler(value={CustomException.class})
     public ResponseEntity<ApiResponse<?>> handleCustomException(CustomException e){
-        log.error("handleCustomException() in GlobalExceptionHandler throw CustomException : {}", e.getMessage());
+        Map<String, Object> parameters = e.getParameters();
+        if(e.getLogMethod() != null){
+            e.getLogMethod().accept("CustomException occured : " + parameters);
+        }
         return ResponseEntity
             .status(e.getErrorCode().getHttpStatus())
             .body(ApiResponse.createFail(e));
     }
-
+    @Order(2)
     @ExceptionHandler(ConstraintViolationException.class)
-    public ResponseEntity<?> handleConstraintViolationException(ConstraintViolationException e) {
-        log.error("handleConstraintViolationException() in GlobalExceptionHandler throw ConstraintViolationException : {}", e.getMessage());
+    public ResponseEntity<ApiResponse<?>> handleConstraintViolationException(ConstraintViolationException e) {
         String errorMessage = e.getConstraintViolations().iterator().next().getMessage();
+        log.error("ConstraintViolationException occured : " + errorMessage);
+
         return new ResponseEntity<>(ApiResponse.createFailWithBindingResult(errorMessage),
             HttpStatus.BAD_REQUEST);
+    }
+
+    @Order(99)
+    @ExceptionHandler(value={Exception.class}) // 모든 예외에 대해 처리함
+    public ResponseEntity<ApiResponse<?>> handleException(Exception e){
+        log.debug("Exception occured : " + Arrays.toString(e.getStackTrace()));
+        // 모든 예외에 대해 처리할때 httpStatus는 어떤걸로 지정해야할지 모르겠음
+        return new ResponseEntity<>(ApiResponse.createFail(e), HttpStatus.BAD_REQUEST);
     }
 }

--- a/src/main/java/com/flab/s_market/domains/term/controller/TermController.java
+++ b/src/main/java/com/flab/s_market/domains/term/controller/TermController.java
@@ -25,11 +25,11 @@ public class TermController {
     }
 
     @GetMapping("/terms/detail")
-    public ApiResponse<DetailTermDTO> getDetailTerms( // 1. termId==Null 이면 스프링에서 알수없는 에러 2. termId ==Nullable로해서 customException처리
-        // 상황에 따라 판단해서 1,2 선택해라
+    public ApiResponse<DetailTermDTO> getDetailTerms(
         @RequestParam(name = "termId") Long termId,
         @RequestParam(name = "version") Integer version
     ){
-        return ApiResponse.createSuccess(termService.getDetailTerms(termId, version));
+        DetailTermDTO responseDTO = termService.getDetailTerms(termId, version);
+        return ApiResponse.createSuccess(responseDTO);
     }
 }

--- a/src/main/java/com/flab/s_market/domains/term/dto/response/TermsResponseDTO.java
+++ b/src/main/java/com/flab/s_market/domains/term/dto/response/TermsResponseDTO.java
@@ -6,7 +6,7 @@ public record TermsResponseDTO (
     String title,
     List<TermResponseDTO> terms
     ){
-
+    // 인터페이스 활용
     public static TermsResponseDTO from(String title, List<TermResponseDTO> termList){
         return new TermsResponseDTO(title, termList);
     }

--- a/src/main/java/com/flab/s_market/domains/term/service/TermService.java
+++ b/src/main/java/com/flab/s_market/domains/term/service/TermService.java
@@ -1,5 +1,7 @@
 package com.flab.s_market.domains.term.service;
 
+import com.flab.s_market.common.exception.CustomException;
+import com.flab.s_market.common.exception.ErrorCode;
 import com.flab.s_market.domains.term.domain.Term;
 import com.flab.s_market.domains.term.dto.response.AllTermResponseDTO;
 import com.flab.s_market.domains.term.dto.response.DetailTermDTO;
@@ -9,7 +11,10 @@ import com.flab.s_market.domains.term.repository.SubTermRepository;
 import com.flab.s_market.domains.term.repository.TermRepository;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 import lombok.RequiredArgsConstructor;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -19,8 +24,10 @@ import org.springframework.transaction.annotation.Transactional;
 public class TermService {
 
     private final TermRepository termRepository;
+    private final SubTermRepository subTermRepository;
     private static final String mainTitle = "이용약관에 먼저 동의해주세요";
     private static final String additionalTitle = "신규 가입 회원에게만 드려요.\\n 유니버스 크럽 3개월 무료 이용!";
+    private Logger log = LoggerFactory.getLogger(TermService.class);
     public AllTermResponseDTO getAllTerms(){
         List<Term> terms = termRepository.findAll(); // 쿼리 확인
         List<TermResponseDTO> mainTermList = new ArrayList<>();
@@ -41,11 +48,8 @@ public class TermService {
     }
 
     public DetailTermDTO getDetailTerms(Long termId, Integer version) {
-          return null;
-//        return subTermRepository.findByTermIdAndVersion(termId, version);
-//            subTermRepository.findByTermIdAndVersion(termId, version);
-//            .orElseThrow(() -> new CustomException(ErrorCode.NOT_EXIST_TERM, Map.of("termId", termId, "version", version),
-//                log::info));
-        // optional리턴해서 없으면 예외처리
+        return subTermRepository.findByTermIdAndVersion(termId, version)
+            .orElseThrow(() ->
+                new CustomException(ErrorCode.NOT_EXIST_TERM, Map.of("termId", termId, "version", version), log::info));
     }
 }


### PR DESCRIPTION
## #️⃣ 연관된 이슈

- #2 

## 📝 구현 기능 명세

- Optional을 이용해서 레포지토리 조회시 null일 경우 customException 예외처리
- user_sub_term 테이블의 agree_date 대신 agree로 변경(기획자 의견에 따라 달라지며, createdAt이 동의날짜 역할을 대신 해주기에)
- exception에 대한 순서를 정해두어, CustomException이 가장 먼저 처리되도록 하며, 이외의 예외도 클라이언트가 알아볼 수 있는 예외 메세지 던지도록 처리
- CustomException 클래스에 exception 필드를 추가하여, 커스텀 예외 이외 예외 발생시 해당 예외를 담도록 추가

### 📷 스크린샷 (선택)

❌

## 💬 어려웠던 점

❌