### PR TITLE
[#2] 약관 상세조회 api 리펙터링

### DIFF
--- a/src/main/java/com/flab/s_market/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/flab/s_market/common/exception/GlobalExceptionHandler.java
@@ -39,7 +39,7 @@ public class GlobalExceptionHandler {
     @Order(99)
     @ExceptionHandler(value={Exception.class}) // 모든 예외에 대해 처리함
     public ResponseEntity<ApiResponse<?>> handleException(Exception e){
-        log.debug("Exception occured : " + Arrays.toString(e.getStackTrace()));
+        log.error("Exception occured : " + Arrays.toString(e.getStackTrace()));
         // 모든 예외에 대해 처리할때 httpStatus는 어떤걸로 지정해야할지 모르겠음
         return new ResponseEntity<>(ApiResponse.createFail(e), HttpStatus.BAD_REQUEST);
     }

--- a/src/main/java/com/flab/s_market/domains/term/dto/response/DetailTermDTO.java
+++ b/src/main/java/com/flab/s_market/domains/term/dto/response/DetailTermDTO.java
@@ -1,9 +1,13 @@
 package com.flab.s_market.domains.term.dto.response;
 
+import com.flab.s_market.domains.term.domain.SubTerm;
+
 public record DetailTermDTO (
     String url,
     Integer version,
     String title
     ){
-
+    public static DetailTermDTO from(SubTerm subTerm){
+        return new DetailTermDTO(subTerm.getUrl(), subTerm.getId().getVersion(), subTerm.getTerm().getTitle());
+    }
 }

--- a/src/main/java/com/flab/s_market/domains/term/repository/SubTermCustomRepository.java
+++ b/src/main/java/com/flab/s_market/domains/term/repository/SubTermCustomRepository.java
@@ -1,7 +1,8 @@
 package com.flab.s_market.domains.term.repository;
 
-import com.flab.s_market.domains.term.dto.response.DetailTermDTO;
+import com.flab.s_market.domains.term.domain.SubTerm;
+import java.util.Optional;
 
 public interface SubTermCustomRepository {
-    public DetailTermDTO findByTermIdAndVersion(Long termId, Integer version);
+    Optional<SubTerm> findByTermIdAndVersion(Long termId, Integer version);
 }

--- a/src/main/java/com/flab/s_market/domains/term/repository/SubTermCustomRepositoryImpl.java
+++ b/src/main/java/com/flab/s_market/domains/term/repository/SubTermCustomRepositoryImpl.java
@@ -1,10 +1,10 @@
 package com.flab.s_market.domains.term.repository;
 
 import com.flab.s_market.domains.term.domain.QSubTerm;
-import com.flab.s_market.domains.term.dto.response.DetailTermDTO;
-import com.querydsl.core.types.Projections;
+import com.flab.s_market.domains.term.domain.SubTerm;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import jakarta.persistence.EntityManager;
+import java.util.Optional;
 
 public class SubTermCustomRepositoryImpl implements SubTermCustomRepository{
 
@@ -15,18 +15,20 @@ public class SubTermCustomRepositoryImpl implements SubTermCustomRepository{
     }
 
     @Override
-    public DetailTermDTO findByTermIdAndVersion(Long termId, Integer version) {
+    public Optional<SubTerm> findByTermIdAndVersion(Long termId, Integer version) {
         QSubTerm subTerm = QSubTerm.subTerm;
 
-        return queryFactory
-            .select(Projections.constructor(
-                DetailTermDTO.class,
-                subTerm.url,
-                subTerm.id.version,
-                subTerm.term.title
-            ))
+        SubTerm sub = queryFactory
+            .select(subTerm)
             .from(subTerm)
             .where(subTerm.id.termId.eq(termId), subTerm.id.version.eq(version))
             .fetchOne();
+
+        return Optional.ofNullable(sub);
+        /*if(sub == null){
+            return Optional.empty();
+        }else{
+            return Optional.of(sub);
+        }*/
     }
 }

--- a/src/main/java/com/flab/s_market/domains/term/repository/SubTermRepository.java
+++ b/src/main/java/com/flab/s_market/domains/term/repository/SubTermRepository.java
@@ -2,8 +2,10 @@ package com.flab.s_market.domains.term.repository;
 
 import com.flab.s_market.domains.term.domain.SubTerm;
 import com.flab.s_market.domains.term.domain.SubTermId;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface SubTermRepository extends JpaRepository<SubTerm, SubTermId>, SubTermCustomRepository {
-
+    Optional<SubTerm> findByTermIdAndVersion(Long termId, Integer version);
+    // 보통은 엔티티로 반환해서 서비스에서 변환, 더 다양하게 쓸 수 있도록 하기 위함.
 }

--- a/src/main/java/com/flab/s_market/domains/term/service/TermService.java
+++ b/src/main/java/com/flab/s_market/domains/term/service/TermService.java
@@ -2,6 +2,7 @@ package com.flab.s_market.domains.term.service;
 
 import com.flab.s_market.common.exception.CustomException;
 import com.flab.s_market.common.exception.ErrorCode;
+import com.flab.s_market.domains.term.domain.SubTerm;
 import com.flab.s_market.domains.term.domain.Term;
 import com.flab.s_market.domains.term.dto.response.AllTermResponseDTO;
 import com.flab.s_market.domains.term.dto.response.DetailTermDTO;
@@ -48,8 +49,10 @@ public class TermService {
     }
 
     public DetailTermDTO getDetailTerms(Long termId, Integer version) {
-        return subTermRepository.findByTermIdAndVersion(termId, version)
+        SubTerm subTerm = subTermRepository.findByTermIdAndVersion(termId, version)
             .orElseThrow(() ->
                 new CustomException(ErrorCode.NOT_EXIST_TERM, Map.of("termId", termId, "version", version), log::info));
+
+        return DetailTermDTO.from(subTerm);
     }
 }


### PR DESCRIPTION
## #️⃣ 연관된 이슈

- #2 

## 📝 구현 기능 명세

- 레포지토리로 데이터 조회시 dto 대신 엔티티로 반환받도록 변경
- 엔티티를 dto로 변경할 수 있도록 static 메서드 추가

### 📷 스크린샷 (선택)

❌

## 💬 참고할 점

![image](https://github.com/user-attachments/assets/3a281bc3-dbb6-4fbd-832e-5e0975df7b82)

- null 허용을 막기 위해 원시형으로 작성하고자 했으나, 엔티티 상에는 이 둘이 참조형으로 선언되어있어 허용되지 않는다. 추후 다시 고쳐봐야한다. 