### PR TITLE
[#3, #4] 이메일 중복체크 api, 이메일 인증코드 발송 api 리펙터링

### DIFF
--- a/src/main/java/com/flab/s_market/domains/user/controller/v1/UserController.java
+++ b/src/main/java/com/flab/s_market/domains/user/controller/v1/UserController.java
@@ -7,6 +7,7 @@ import com.flab.s_market.domains.user.dto.request.JoinInfoDTO;
 import com.flab.s_market.domains.user.service.EmailService;
 import com.flab.s_market.domains.user.service.UserService;
 import jakarta.validation.Valid;
+import jakarta.validation.constraints.Email;
 import lombok.RequiredArgsConstructor;
 import org.springframework.validation.BindingResult;
 import org.springframework.validation.annotation.Validated;
@@ -26,7 +27,7 @@ public class UserController {
     private final EmailService emailService;
 
     @GetMapping("/email/checkDuplicated")
-    public void getCheckEmailDuplicated(@RequestParam(value = "email") String email){
+    public void getCheckEmailDuplicated(@RequestParam(value = "email") @Email @Valid String email){
         userService.checkEmailDuplicated(email);
     }
 
@@ -36,7 +37,8 @@ public class UserController {
     }
     @PostMapping("/verifyCode")
     public ApiResponse<String> verifyCode(@RequestBody EmailCodeDTO dto){
-        return ApiResponse.createSuccess(emailService.verifyEmailCode(dto));
+        String responseData = emailService.verifyEmailCode(dto);
+        return ApiResponse.createSuccess(responseData);
     }
 
     @PostMapping("/join")

--- a/src/main/java/com/flab/s_market/domains/user/domain/UserSubTerm.java
+++ b/src/main/java/com/flab/s_market/domains/user/domain/UserSubTerm.java
@@ -8,7 +8,6 @@ import jakarta.persistence.FetchType;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.MapsId;
-import java.time.LocalDateTime;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -22,8 +21,9 @@ public class UserSubTerm extends BaseEntity {
     @EmbeddedId
     private UserSubTermId id;
 
+    // 동의한것만 저장? 안한것도 저장? 이건 기획자랑 얘기하면 됨
     @Column(nullable = false)
-    private LocalDateTime agreeDate;
+    private boolean agree;
 
     @MapsId("userId")
     @ManyToOne(fetch = FetchType.LAZY)

--- a/src/main/java/com/flab/s_market/domains/user/service/EmailService.java
+++ b/src/main/java/com/flab/s_market/domains/user/service/EmailService.java
@@ -1,17 +1,14 @@
 package com.flab.s_market.domains.user.service;
 
-import com.flab.s_market.common.config.AES128Config;
+import com.flab.s_market.common.config.EncryptionService;
 import com.flab.s_market.common.exception.CustomException;
 import com.flab.s_market.common.exception.ErrorCode;
 import com.flab.s_market.domains.user.dto.request.EmailCodeDTO;
 import jakarta.mail.MessagingException;
 import jakarta.mail.internet.MimeMessage;
-import java.security.MessageDigest;
-import java.security.NoSuchAlgorithmException;
 import java.time.Duration;
-import java.time.LocalDateTime;
-import java.util.Base64;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Random;
 import lombok.RequiredArgsConstructor;
 import org.slf4j.Logger;
@@ -31,7 +28,7 @@ import org.thymeleaf.templateresolver.ClassLoaderTemplateResolver;
 public class EmailService {
     private final JavaMailSender mailSender;
     private final StringRedisTemplate redisTemplate;
-    private final AES128Config aes128Config;
+    private final EncryptionService encryptionService;
     private Logger log = LoggerFactory.getLogger(EmailService.class);
 
     @Value("${spring.mail.username}")
@@ -70,16 +67,13 @@ public class EmailService {
 
 
     // 메일 반환
-    private MimeMessage createEmailForm(String email) throws MessagingException {
-
-        String authCode = createdCode();
+    private MimeMessage createEmailForm(String email, String authCode) throws MessagingException {
 
         MimeMessage message = mailSender.createMimeMessage();
         message.addRecipients(MimeMessage.RecipientType.TO, email);
         message.setSubject("S market 인증 코드");
         message.setFrom(configEmail);
         message.setText(setContext(authCode), "utf-8", "html");
-        setDataExpire(email, authCode, 60 * 30L);
 
         return message;
     }
@@ -87,14 +81,17 @@ public class EmailService {
 
     // 메일 보내기
     public void sendEmail(String toEmail){
-        if (existData(toEmail)) {
-            deleteData(toEmail);
+        if (existEmailData(toEmail)) {
+            throw new CustomException(ErrorCode.NOT_PASSED_FIVE_MINUTES, Map.of("email", toEmail), log::info);
         }
+
         try {
-            MimeMessage emailForm = createEmailForm(toEmail);
+            String authCode = createdCode();
+            MimeMessage emailForm = createEmailForm(toEmail, authCode);
+            setDataWithTTL(toEmail, authCode, 60 * 5L);
             mailSender.send(emailForm);
         }catch(Exception e){
-            throw new CustomException(ErrorCode.MAIL_SYSTEM_ERROR, Map.of("email", toEmail), log::warn);
+            throw new CustomException(ErrorCode.MAIL_SYSTEM_ERROR, Map.of("email", toEmail), log::warn, e); // i/o exception
         }
     }
 
@@ -102,45 +99,38 @@ public class EmailService {
     public String verifyEmailCode(EmailCodeDTO dto){
         String email = dto.email();
         String code = dto.code();
-        String codeFoundByEmail = getData(dto.email());
+        Optional<String> codeFoundByEmail = getEmailDataIfExist(dto.email());
         System.out.println(codeFoundByEmail);
-        if (codeFoundByEmail == null) {
+        if (!codeFoundByEmail.isPresent()) {
             throw new CustomException(ErrorCode.NOT_VALID_EMAIL_CODE,
                 Map.of("email", email, "emailCode", code), log::info);
         }
-        deleteData(email);
-        String emailKey = aes128Config.encryptAes(email);
-        setDataExpire(email, emailKey, 60*30L);
+        deleteEmailData(email);
+        String emailKey = encryptionService.encrypt(email); // 추상적인 이름 써라
+        setDataWithTTL(email, emailKey, 60*30L);
 
         log.info("enc = {}", emailKey);
 
         return emailKey;
     }
 
-    public String makeMemberId(String email) throws NoSuchAlgorithmException {
-        MessageDigest md = MessageDigest.getInstance("SHA-256");
-        md.update(email.getBytes());
-        md.update(LocalDateTime.now().toString().getBytes());
-        byte[] digest = md.digest();
-        return Base64.getEncoder().encodeToString(digest);
-    }
-
-    public void setDataExpire(String key, String value, long duration) {
+    public void setDataWithTTL(String key, String value, long duration) {
         ValueOperations<String, String> valueOperations = redisTemplate.opsForValue();
         Duration expireDuration = Duration.ofSeconds(duration);
         valueOperations.set(key, value, expireDuration);
     }
 
-    public String getData(String key) {
+    public Optional<String> getEmailDataIfExist(String key) {
         ValueOperations<String, String> valueOperations = redisTemplate.opsForValue();
-        return valueOperations.get(key);
+        return Optional.ofNullable(valueOperations.get(key));
     }
 
-    public boolean existData(String key) {
+    public boolean existEmailData(String key) {
         return Boolean.TRUE.equals(redisTemplate.hasKey(key));
     }
 
-    public void deleteData(String key) {
+    public void deleteEmailData(String key) { // TTL에 의해 사라졌다면 문제임, 없는 값 지울때 에러가 안나기도 하지만 확인해봐라
+        // 없다면 무시하면됨
         redisTemplate.delete(key);
     }
 }


### PR DESCRIPTION
## #️⃣ 연관된 이슈

- #3 
- #4 

## 📝 구현 기능 명세

- 이메일로 인증코드 발송시, 파라미터로 넘어온 문자열에 대해 이메일 형식인지 유효성 검사
- 단일 책임의 원칙에 따라 한번에 하나의 책임만 갖도록 메서드 내부 수정, 분리
- userSubTerm 엔티티가 동의 날짜 대신 동의 여부를 필드로 갖도록 수정

### 📷 스크린샷 (선택)

❌

## 💬 어려웠던 점

❌
