### PR TITLE
[#5] 이메일 인증코드 검증 api 코드 스타일 변경 및 예외 핸들러 로그 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -47,6 +47,9 @@ dependencies {
 	// query parameter log
 	implementation 'com.github.gavlyukovskiy:p6spy-spring-boot-starter:1.9.0'
 
+	// apache ExceptionUtil
+	implementation 'commons-configuration:commons-configuration:1.9'
+
 	// mysql db
 	runtimeOnly 'com.mysql:mysql-connector-j'
 	testImplementation 'org.testcontainers:mysql'

--- a/src/main/java/com/flab/s_market/common/config/EncryptionService.java
+++ b/src/main/java/com/flab/s_market/common/config/EncryptionService.java
@@ -9,18 +9,22 @@ import java.security.NoSuchAlgorithmException;
 import java.security.SecureRandom;
 import java.util.Arrays;
 import java.util.Base64;
+import java.util.Map;
 import javax.crypto.Cipher;
 import javax.crypto.NoSuchPaddingException;
 import javax.crypto.spec.IvParameterSpec;
 import javax.crypto.spec.SecretKeySpec;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 
 @Component
-public class AES128Config {
+public class EncryptionService {
     private static final Charset ENCODING_TYPE = StandardCharsets.UTF_8;
     private static final String INSTANCE_TYPE = "AES/CBC/PKCS5Padding";
     private static final int AES_KEY_SIZE = 16;
+    private Logger log = LoggerFactory.getLogger(EncryptionService.class);
 
     @Value("${aes.secret-key}")
     private String secretKey;
@@ -43,24 +47,24 @@ public class AES128Config {
     }
 
     // AES 암호화
-    public String encryptAes(String plaintext){
+    public String encrypt(String plaintext){
         try {
             cipher.init(Cipher.ENCRYPT_MODE, secretKeySpec, ivParameterSpec);
             byte[] encryted = cipher.doFinal(plaintext.getBytes(ENCODING_TYPE)); // 데이터 암호화
             return new String(Base64.getEncoder().encode(encryted), ENCODING_TYPE); // 문자열 인코딩 반환
         } catch (Exception e) {
-            throw new CustomException(ErrorCode.ENCRYPTION_FAILED);
+            throw new CustomException(ErrorCode.ENCRYPTION_FAILED, Map.of("plainText", plaintext), log::warn);
         }
     }
 
     // AES 복호화
-    public String decryptAes(String plaintext) {
+    public String decrypt(String encryptedText) {
         try {
             cipher.init(Cipher.DECRYPT_MODE, secretKeySpec, ivParameterSpec);
-            byte[] decoded = Base64.getDecoder().decode(plaintext.getBytes(ENCODING_TYPE));
+            byte[] decoded = Base64.getDecoder().decode(encryptedText.getBytes(ENCODING_TYPE));
             return new String(cipher.doFinal(decoded), ENCODING_TYPE); // 데이터 복호화, 인코딩 반환
         } catch (Exception e) {
-            throw new CustomException(ErrorCode.DECRYPTION_FAILED);
+            throw new CustomException(ErrorCode.DECRYPTION_FAILED, Map.of("encryptedText", encryptedText), log::warn);
         }
     }
 }

--- a/src/main/java/com/flab/s_market/common/entity/ApiResponse.java
+++ b/src/main/java/com/flab/s_market/common/entity/ApiResponse.java
@@ -21,18 +21,12 @@ public class ApiResponse <T>{
     public static <T> ApiResponse<T> createSuccess(final T data){
         return new ApiResponse<>(SUCCESS_CODE, data);
     }
-    public static ApiResponse<?> createSuccessWithNoContent(){
-        return new ApiResponse<>(SUCCESS_CODE, null);
-    }
+
     public static ApiResponse<?> createFail(final CustomException e){
         return new ApiResponse<>(e.getErrorCode().getCode(), e.getMessage());
     }
 
-    public static ApiResponse<?> createFail(final Exception e){
-        return new ApiResponse<>(VALID_FAIL_CODE, e.getMessage());
-    }
-
-    public static ApiResponse<?> createFailWithBindingResult(final String errorMessage){
+    public static ApiResponse<?> createFailWithErrorMessage(final String errorMessage){
         return new ApiResponse<>(VALID_FAIL_CODE, errorMessage);
     }
 }

--- a/src/main/java/com/flab/s_market/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/flab/s_market/common/exception/GlobalExceptionHandler.java
@@ -2,13 +2,14 @@ package com.flab.s_market.common.exception;
 
 import com.flab.s_market.common.entity.ApiResponse;
 import jakarta.validation.ConstraintViolationException;
-import java.util.Arrays;
 import java.util.Map;
+import org.apache.commons.lang.exception.ExceptionUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.core.annotation.Order;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.MissingServletRequestParameterException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
@@ -20,7 +21,7 @@ public class GlobalExceptionHandler {
     public ResponseEntity<ApiResponse<?>> handleCustomException(CustomException e){
         Map<String, Object> parameters = e.getParameters();
         if(e.getLogMethod() != null){
-            e.getLogMethod().accept("CustomException occured : " + parameters);
+            e.getLogMethod().accept("CustomException occured : parameters - " + parameters);
         }
         return ResponseEntity
             .status(e.getErrorCode().getHttpStatus())
@@ -29,18 +30,28 @@ public class GlobalExceptionHandler {
     @Order(2)
     @ExceptionHandler(ConstraintViolationException.class)
     public ResponseEntity<ApiResponse<?>> handleConstraintViolationException(ConstraintViolationException e) {
-        String errorMessage = e.getConstraintViolations().iterator().next().getMessage();
-        log.error("ConstraintViolationException occured : " + errorMessage);
+        String errorMessage = ExceptionUtils.getFullStackTrace(e);
+        log.error("ConstraintViolationException occured : getFullStackTrace - " + errorMessage);
 
-        return new ResponseEntity<>(ApiResponse.createFailWithBindingResult(errorMessage),
+        return new ResponseEntity<>(ApiResponse.createFailWithErrorMessage(errorMessage),
             HttpStatus.BAD_REQUEST);
     }
 
+    @Order(3)
+    @ExceptionHandler(MissingServletRequestParameterException.class)
+    public ResponseEntity<ApiResponse<?>> handleMissingServletRequestParameterException(MissingServletRequestParameterException e) {
+        String errorMessage = ExceptionUtils.getFullStackTrace(e);
+        log.info("MissingServletRequestParameterException occured : getFullStackTrace - " + errorMessage);
+
+        return new ResponseEntity<>(ApiResponse.createFailWithErrorMessage(errorMessage), HttpStatus.BAD_REQUEST);
+    }
+
     @Order(99)
-    @ExceptionHandler(value={Exception.class}) // 모든 예외에 대해 처리함
+    @ExceptionHandler(value={Exception.class})
     public ResponseEntity<ApiResponse<?>> handleException(Exception e){
-        log.error("Exception occured : " + Arrays.toString(e.getStackTrace()));
+        String errorMessage = ExceptionUtils.getFullStackTrace(e);
+        log.error("Exception occured : getFullStackTrace - " + errorMessage);
         // 모든 예외에 대해 처리할때 httpStatus는 어떤걸로 지정해야할지 모르겠음
-        return new ResponseEntity<>(ApiResponse.createFail(e), HttpStatus.BAD_REQUEST);
+        return new ResponseEntity<>(ApiResponse.createFailWithErrorMessage(errorMessage), HttpStatus.BAD_REQUEST);
     }
 }

--- a/src/main/java/com/flab/s_market/domains/user/service/EmailService.java
+++ b/src/main/java/com/flab/s_market/domains/user/service/EmailService.java
@@ -100,13 +100,12 @@ public class EmailService {
         String email = dto.email();
         String code = dto.code();
         Optional<String> codeFoundByEmail = getEmailDataIfExist(dto.email());
-        System.out.println(codeFoundByEmail);
-        if (!codeFoundByEmail.isPresent()) {
+        if (codeFoundByEmail.isEmpty()) {
             throw new CustomException(ErrorCode.NOT_VALID_EMAIL_CODE,
                 Map.of("email", email, "emailCode", code), log::info);
         }
         deleteEmailData(email);
-        String emailKey = encryptionService.encrypt(email); // 추상적인 이름 써라
+        String emailKey = encryptionService.encrypt(email);
         setDataWithTTL(email, emailKey, 60*30L);
 
         log.info("enc = {}", emailKey);
@@ -129,8 +128,10 @@ public class EmailService {
         return Boolean.TRUE.equals(redisTemplate.hasKey(key));
     }
 
-    public void deleteEmailData(String key) { // TTL에 의해 사라졌다면 문제임, 없는 값 지울때 에러가 안나기도 하지만 확인해봐라
-        // 없다면 무시하면됨
-        redisTemplate.delete(key);
+    public void deleteEmailData(String key) {
+        Optional<String> emailDataIfExist = getEmailDataIfExist(key);
+        if(emailDataIfExist.isPresent()){
+            redisTemplate.delete(key);
+        }
     }
 }

--- a/src/test/java/com/flab/s_market/EmailTest.java
+++ b/src/test/java/com/flab/s_market/EmailTest.java
@@ -1,10 +1,6 @@
 package com.flab.s_market;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertTrue;
-
-import com.flab.s_market.common.config.AES128Config;
+import com.flab.s_market.common.config.EncryptionService;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -20,15 +16,15 @@ import org.springframework.test.context.junit.jupiter.SpringExtension;
 public class EmailTest {
 
     @Autowired
-    private AES128Config aes128Config;
+    private EncryptionService encryptionService;
     private Logger log = LoggerFactory.getLogger(this.getClass().getSimpleName());
 
     @Test
     @DisplayName("Aes128 암호화가 잘 되는지 확인 테스트")
     public void aes128Test(){
         String text = "this is test";
-        String enc = aes128Config.encryptAes(text);
-        String dec = aes128Config.decryptAes(enc);
+        String enc = encryptionService.encrypt(text);
+        String dec = encryptionService.decrypt(enc);
         log.info("enc = {}", enc);
         log.info("dec = {}", dec);
     }


### PR DESCRIPTION
## #️⃣ 연관된 이슈

- #5 

## 📝 구현 기능 명세

- (이메일, 인증코드)가 레디스에 저장된 후 TTL에 의해 사라졌을 수도 있고 아직 TTL이 지나지 않았을 수도 있으므로 key가 현재 레디스에 존재하는지 확인 후 레디스에서 제거하도록 수정
- 특정 암호의 내용을 알 수 없도록 하기위해서 추상적인 명칭을 가진 클래스명 EncryptionService로 변경
- build.gradle에 아파치의 commons-configuration 패키지 추가
- 아파치의 ExceptionUtils 클래스의 exception Stack trace를 출력하도록 로그 출력하는 코드 추가
- ApiResponse 중에서 사용하지 않는 메서드 삭제 및 구체적인 메서드명으로 수정

### 📷 스크린샷 (선택)

❌

## 💬 어려웠던 점

❌
