### PR TITLE
[#6] 회원가입 api 구현 - 동의하지 않은 약관 내용을 포함한 db 추가

### DIFF
--- a/src/main/generated/com/flab/s_market/domains/user/domain/QUserSubTerm.java
+++ b/src/main/generated/com/flab/s_market/domains/user/domain/QUserSubTerm.java
@@ -24,7 +24,7 @@ public class QUserSubTerm extends EntityPathBase<UserSubTerm> {
 
     public final com.flab.s_market.common.entity.QBaseEntity _super = new com.flab.s_market.common.entity.QBaseEntity(this);
 
-    public final DateTimePath<java.time.LocalDateTime> agreeDate = createDateTime("agreeDate", java.time.LocalDateTime.class);
+    public final BooleanPath agree = createBoolean("agree");
 
     //inherited
     public final DateTimePath<java.time.LocalDateTime> createdAt = _super.createdAt;

--- a/src/main/java/com/flab/s_market/common/config/EncryptionService.java
+++ b/src/main/java/com/flab/s_market/common/config/EncryptionService.java
@@ -64,7 +64,7 @@ public class EncryptionService {
             byte[] decoded = Base64.getDecoder().decode(encryptedText.getBytes(ENCODING_TYPE));
             return new String(cipher.doFinal(decoded), ENCODING_TYPE); // 데이터 복호화, 인코딩 반환
         } catch (Exception e) {
-            throw new CustomException(ErrorCode.DECRYPTION_FAILED, Map.of("encryptedText", encryptedText), log::warn);
+            throw new CustomException(ErrorCode.DECRYPTION_FAILED, Map.of("encryptedText", encryptedText), log::info);
         }
     }
 }

--- a/src/main/java/com/flab/s_market/common/config/SecurityConfig.java
+++ b/src/main/java/com/flab/s_market/common/config/SecurityConfig.java
@@ -2,9 +2,11 @@ package com.flab.s_market.common.config;
 
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
-import org.springframework.security.config.annotation.web.configuration.WebSecurityCustomizer;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.web.SecurityFilterChain;
 
 @Configuration
 @EnableWebSecurity
@@ -15,10 +17,15 @@ public class SecurityConfig {
     }
 
     @Bean
-    public WebSecurityCustomizer configure() {
-        return (web) -> web.ignoring()
-//                .requestMatchers(toH2Console())
-            .requestMatchers("/v1/api/**");
+    public SecurityFilterChain configure(HttpSecurity http) throws Exception {
+        http
+            .authorizeHttpRequests(auth -> auth
+                .requestMatchers("/v1/api/**").permitAll() // 특정 경로 허용
+                .anyRequest().authenticated() // 나머지는 인증 필요
+            )
+            .csrf(AbstractHttpConfigurer::disable); // 필요에 따라 CSRF 설정
+
+        return http.build();
     }
 
 }

--- a/src/main/java/com/flab/s_market/common/exception/ErrorCode.java
+++ b/src/main/java/com/flab/s_market/common/exception/ErrorCode.java
@@ -10,12 +10,14 @@ public enum ErrorCode {
     EXIST_EMAIL("ACCOUNT-001", "이미 사용중인 이메일입니다. 다른 이메일을 작성해주세요.", HttpStatus.BAD_REQUEST),
     NOT_VALID_EMAIL_CODE("ACCOUNT-002", "인증코드가 틀립니다. 이메일을 확인해주세요.", HttpStatus.NOT_FOUND),
     NOT_VALID_PASSWORD("ACCOUNT-03", "비밀번호와 재확인 비밀번호가 다릅니다. 비밀번호를 다시 확인해주세요.", HttpStatus.BAD_REQUEST),
-    NOT_EXIST_TERM("ACCOUNT-04", "존재하지 않는 약관입니다. 약관 버전 또는 약관명을 다시 확인해주세요.", HttpStatus.NOT_FOUND),
+    NOT_MATCH_TERM_VERSION("ACCOUNT-04", "약관 버전이 잘못 되었습니다. 약관 버전을 다시 확인해주세요.", HttpStatus.NOT_FOUND),
     MAIL_SYSTEM_ERROR("ACCOUNT-05", "이메일 시스템 에러가 발생했습니다. 발송 이메일을 다시 확인해주세요.", HttpStatus.INTERNAL_SERVER_ERROR),
     ENCRYPTION_FAILED("ACCOUNT-06", "이메일 암호화에 실패하였습니다. 다시 시도해주세요.", HttpStatus.INTERNAL_SERVER_ERROR),
     DECRYPTION_FAILED("ACCOUNT-07", "이메일키 복호화에 실패하였습니다. 다시 시도해주세요.", HttpStatus.INTERNAL_SERVER_ERROR),
     NOT_ALL_AGREED_REQUIRED_TERMS("ACCOUNT-08", "필수 약관에 모두 동의해야합니다.", HttpStatus.BAD_REQUEST),
-    NOT_PASSED_FIVE_MINUTES("ACCOUNT-09", "이메일에 인증코드를 발송한 지 5분이 지나지 않았습니다. 이메일을 확인해주세요.", HttpStatus.NOT_FOUND);
+    NOT_PASSED_FIVE_MINUTES("ACCOUNT-09", "이메일에 인증코드를 발송한 지 5분이 지나지 않았습니다. 이메일을 확인해주세요.", HttpStatus.NOT_FOUND),
+    NOT_EXIST_TERM("ACCOUNT-10", "존재하지 않는 약관 이름 또는 약관 버전입니다. 약관 이름 또는 약관 버전을 확인해주세요.", HttpStatus.NOT_FOUND),
+    EXIST_USER("ACCOUNT-11", "이미 해당 계정은 회원가입되어있습니다. 이메일을 다시 확인해주세요.", HttpStatus.BAD_REQUEST);
 
     private final String code;
     private final String message;

--- a/src/main/java/com/flab/s_market/domains/term/repository/TermCustomRepository.java
+++ b/src/main/java/com/flab/s_market/domains/term/repository/TermCustomRepository.java
@@ -2,9 +2,7 @@ package com.flab.s_market.domains.term.repository;
 
 import com.flab.s_market.domains.term.domain.SubTerm;
 import java.util.List;
-import java.util.Optional;
 
 public interface TermCustomRepository {
-    Optional<SubTerm> findByTitleAndVersionWithJoin(String title, Integer version);
     List<SubTerm> findByTermIdAndVersionWithJoin();
 }

--- a/src/main/java/com/flab/s_market/domains/term/repository/TermCustomRepositoryImpl.java
+++ b/src/main/java/com/flab/s_market/domains/term/repository/TermCustomRepositoryImpl.java
@@ -3,35 +3,15 @@ package com.flab.s_market.domains.term.repository;
 import com.flab.s_market.domains.term.domain.QSubTerm;
 import com.flab.s_market.domains.term.domain.QTerm;
 import com.flab.s_market.domains.term.domain.SubTerm;
-import com.querydsl.jpa.JPAExpressions;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import jakarta.persistence.EntityManager;
 import java.util.List;
-import java.util.Optional;
 
 public class TermCustomRepositoryImpl implements TermCustomRepository{
     private final JPAQueryFactory queryFactory;
 
     public TermCustomRepositoryImpl(EntityManager em) {
         this.queryFactory = new JPAQueryFactory(em);
-    }
-
-    @Override
-    public Optional<SubTerm> findByTitleAndVersionWithJoin(String title, Integer version) {
-        QTerm term = QTerm.term;
-        QSubTerm subTerm = QSubTerm.subTerm;
-
-        return Optional.ofNullable(
-            queryFactory
-                .select(subTerm)
-                .from(subTerm)
-                .where(subTerm.term.in(
-                    JPAExpressions
-                        .selectFrom(term)
-                        .where(term.title.eq(title))
-                ), subTerm.id.version.eq(version))
-                .fetchOne()
-        );
     }
 
     @Override
@@ -42,12 +22,9 @@ public class TermCustomRepositoryImpl implements TermCustomRepository{
         return queryFactory
                 .select(subTerm)
                 .from(subTerm)
-                .where(subTerm.term.in(
-                    JPAExpressions
-                        .selectFrom(term)
-                        .where(term.isRequired.eq(true))
-                ), subTerm.id.version.eq(
-                    queryFactory.select(subTerm.id.version.max())
+                .where(subTerm.id.version.eq(
+                    queryFactory
+                        .select(subTerm.id.version.max())
                         .from(subTerm)
                 ))
                 .fetch();

--- a/src/main/java/com/flab/s_market/domains/user/dto/request/AgreedTermDTO.java
+++ b/src/main/java/com/flab/s_market/domains/user/dto/request/AgreedTermDTO.java
@@ -1,6 +1,9 @@
 package com.flab.s_market.domains.user.dto.request;
 
+import com.flab.s_market.domains.term.domain.SubTerm;
+
 public record AgreedTermDTO (
     String title,
     Integer version
-    ){ }
+    ){
+}

--- a/src/main/java/com/flab/s_market/domains/user/dto/request/JoinInfoDTO.java
+++ b/src/main/java/com/flab/s_market/domains/user/dto/request/JoinInfoDTO.java
@@ -4,7 +4,6 @@ import com.flab.s_market.domains.user.domain.User;
 import com.flab.s_market.domains.user.domain.UserSubTerm;
 import com.flab.s_market.domains.user.domain.UserSubTermId;
 import jakarta.validation.constraints.NotBlank;
-import java.time.LocalDateTime;
 import java.util.List;
 
 public record JoinInfoDTO (
@@ -21,7 +20,7 @@ public record JoinInfoDTO (
     public User toUserEntity(String email, String encPassword) {
         return new User(email, userName, encPassword);
     }
-    public UserSubTerm toUserSubTermEntity(UserSubTermId id, LocalDateTime agreeDate, User user){
-        return new UserSubTerm(id, agreeDate, user);
+    public UserSubTerm toUserSubTermEntity(UserSubTermId id, boolean agree, User user){
+        return new UserSubTerm(id, agree, user);
     }
 }

--- a/src/main/java/com/flab/s_market/domains/user/service/UserService.java
+++ b/src/main/java/com/flab/s_market/domains/user/service/UserService.java
@@ -1,9 +1,10 @@
 package com.flab.s_market.domains.user.service;
 
-import com.flab.s_market.common.config.AES128Config;
+import com.flab.s_market.common.config.EncryptionService;
 import com.flab.s_market.common.exception.CustomException;
 import com.flab.s_market.common.exception.ErrorCode;
 import com.flab.s_market.domains.term.domain.SubTerm;
+import com.flab.s_market.domains.term.domain.Term;
 import com.flab.s_market.domains.term.repository.TermRepository;
 import com.flab.s_market.domains.user.domain.User;
 import com.flab.s_market.domains.user.domain.UserSubTermId;
@@ -11,11 +12,11 @@ import com.flab.s_market.domains.user.dto.request.AgreedTermDTO;
 import com.flab.s_market.domains.user.dto.request.JoinInfoDTO;
 import com.flab.s_market.domains.user.repository.UserRepository;
 import com.flab.s_market.domains.user.repository.UserSubTermRepository;
-import java.time.LocalDateTime;
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
+import org.apache.commons.lang.ObjectUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
@@ -31,7 +32,7 @@ public class UserService {
     private final TermRepository termRepository;
     private final UserSubTermRepository userSubTermRepository;
     private final EmailService emailService;
-    private final AES128Config aes128Config;
+    private final EncryptionService encryptionService;
     private final BCryptPasswordEncoder bCryptPasswordEncoder;
 
     public void checkEmailDuplicated(String email) {
@@ -45,45 +46,63 @@ public class UserService {
         String encPassword = bCryptPasswordEncoder.encode(rawPassword);
         String confirmPassword = dto.confirmPassword();
         String emailKey = dto.emailKey();
-        String email = aes128Config.decryptAes(emailKey);
+        String email = encryptionService.decrypt(emailKey);
 
-        List<AgreedTermDTO> terms = dto.agreedTerms();
-        List<SubTerm> agreedTerms = new ArrayList<>();
-        List<SubTerm> haveToAgreeTerms = termRepository.findByTermIdAndVersionWithJoin();
-
-        if(!rawPassword.equals(confirmPassword)){
-            throw new CustomException(ErrorCode.NOT_VALID_PASSWORD,
-                Map.of("password", rawPassword, "confirmPassword", confirmPassword),
-                log::info);
+        if(userRepository.existsByEmail(email)){
+            throw new CustomException(ErrorCode.EXIST_USER, Map.of("email", email), log::info);
         }
 
-        for (AgreedTermDTO term : terms) {
-            SubTerm findTerm = termRepository.findByTitleAndVersionWithJoin(term.title(), term.version())
-                .orElseThrow(() ->
-                    new CustomException(ErrorCode.NOT_EXIST_TERM,
-                        Map.of("agreedTerms", agreedTerms), log::info));
-
-            agreedTerms.add(findTerm);
-        }
-
-        if(!agreedTerms.containsAll(haveToAgreeTerms)){
-            throw new CustomException(ErrorCode.NOT_ALL_AGREED_REQUIRED_TERMS,
-                Map.of("agreedTerms", agreedTerms, "haveToAgreeTerms", haveToAgreeTerms), log::info);
-        }
-
-        if(!emailService.existData(email)){
+        if(!emailService.existEmailData(email)){
             throw new CustomException(ErrorCode.DECRYPTION_FAILED, Map.of("emailKey", emailKey), log::info);
         }
 
-        // 해시
-        User savedUser = userRepository.save(dto.toUserEntity(email, encPassword));
-        for (SubTerm agreedTerm : agreedTerms) {
-            UserSubTermId userSubTermId = UserSubTermId.builder()
-                .userId(savedUser.getId())
-                .subTerm(agreedTerm)
-                .build();
-            userSubTermRepository.save(dto.toUserSubTermEntity(userSubTermId, LocalDateTime.now(), savedUser));
+        if(!ObjectUtils.equals(rawPassword, confirmPassword)){ // NULL?
+            throw new CustomException(ErrorCode.NOT_VALID_PASSWORD,
+                Map.of("password", rawPassword, "confirmPassword", confirmPassword), log::info);
         }
+
+        List<AgreedTermDTO> agreedTermsDTO = dto.agreedTerms();
+        Map<String, Integer> agreedTermsMap = agreedTermsDTO.stream().collect(
+            Collectors.toMap(AgreedTermDTO::title,AgreedTermDTO::version));
+        List<SubTerm> allTermsInDB = termRepository.findByTermIdAndVersionWithJoin();
+
+        User savedUser = userRepository.save(dto.toUserEntity(email, encPassword));
+        for (SubTerm subTerm : allTermsInDB) {
+            Term term = subTerm.getTerm();
+            if(term.getIsRequired()){
+                if(!agreedTermsMap.containsKey(term.getTitle())){
+                    throw new CustomException(ErrorCode.NOT_ALL_AGREED_REQUIRED_TERMS,
+                        Map.of("agreedTermsDTO", agreedTermsDTO, "allTermsInDB", allTermsInDB), log::info);
+                }else{
+                    if(agreedTermsMap.get(term.getTitle()).equals(subTerm.getId().getVersion())){
+                        saveUserSubTerm(savedUser, dto, true, subTerm);
+                    }else{
+                        throw new CustomException(ErrorCode.NOT_MATCH_TERM_VERSION,
+                            Map.of("agreedSubTerm", subTerm, "version", agreedTermsMap.get(term.getTitle())), log::info);
+                    }
+                }
+            }else{
+                if(!agreedTermsMap.containsKey(term.getTitle())){
+                    saveUserSubTerm(savedUser, dto, false, subTerm);
+                }else{
+                    if(agreedTermsMap.get(term.getTitle()).equals(subTerm.getId().getVersion())){
+                        saveUserSubTerm(savedUser, dto, false, subTerm);
+                    }else{
+                        throw new CustomException(ErrorCode.NOT_MATCH_TERM_VERSION,
+                            Map.of("agreedSubTerm", subTerm, "version", agreedTermsMap.get(term.getTitle())), log::info);
+                    }
+                }
+            }
+        }
+
+    }
+
+    private void saveUserSubTerm(User user, JoinInfoDTO dto, boolean agree, SubTerm subTerm) {
+        UserSubTermId userSubTermId = UserSubTermId.builder()
+            .userId(user.getId())
+            .subTerm(subTerm)
+            .build();
+        userSubTermRepository.save(dto.toUserSubTermEntity(userSubTermId, agree, user));
     }
 
 }


### PR DESCRIPTION
## #️⃣ 연관된 이슈

- #6 

## 📝 구현 기능 명세

- map으로 동의한 약관에 대해 약관명을 key, 약관버전을 value를 가지도록 하여, 전체 약관 정보 list에서 빠르게 존재여부를 찾도록 수정
- 필수 약관 중 동의한 약관에 대해 버전이 예전 버전이라면 예외처리
- 필수 약관 중 동의하지 않은 약관이 있다면 예외처리
- 선택 약관 중 동의한 약관에 대해 예전 버전이면 예외처리
- 이외의 모든 약관에 대해 db에 동의여부 포함 저장

### 📷 스크린샷 (선택)

❌

## 💬 어려웠던 점

❌
