### PR TITLE
[#7] 로그인 api 구현시 발생하는 BadCredentailsException 해결

### DIFF
--- a/src/main/java/com/flab/s_market/domains/security/service/CustomUserDetailsService.java
+++ b/src/main/java/com/flab/s_market/domains/security/service/CustomUserDetailsService.java
@@ -15,7 +15,6 @@ import org.springframework.stereotype.Service;
 public class CustomUserDetailsService implements UserDetailsService {
 
     private final MemberRepository memberRepository;
-    private final BCryptPasswordEncoder passwordEncoder;
 
     // username 존재여부 검증
     @Override
@@ -29,7 +28,7 @@ public class CustomUserDetailsService implements UserDetailsService {
     private UserDetails createUserDetails(Member member) {
         return User.builder()
             .username(member.getEmail())
-            .password(passwordEncoder.encode(member.getPassword()))
+            .password(member.getPassword())
             .authorities(member.getAuthorities())
             .build();
     }


### PR DESCRIPTION
## #️⃣ 연관된 이슈

- #25 

## 📝 구현 기능 명세

- 에러 발생 원인 : ProviderManager 클래스.authenticate() -> AbstractUserDetailsAuthenticationProvider클래스.authenticate() -> additionalAuthenticationChecks() -> DaoAuthenticationProvider클래스.additionalAuthenticationChecks() -> 입력된 rawPassword와 DB상 암호화된 password가 일치하지 않아서 발생한 에러
- CustomUserDetailsService 클래스.createUserDetails()를 통해 DB상에 저장된 email 계정으로 유저정보를 가져올때, password값이 이미 인코딩 되어있으므로 해당 메서드에서 바로 password를 가져오는 것으로 수정

### 📷 스크린샷 (선택)

![2025-02-05 20 04 13](https://github.com/user-attachments/assets/ce2a4be5-a750-4d84-9900-2166578c759d)
![2025-02-05 20 04 13 (2)](https://github.com/user-attachments/assets/a19bb5fb-f20a-4ec5-999a-5185659cb5d3)
![2025-02-05 20 04 13 (3)](https://github.com/user-attachments/assets/4e986258-0a90-41c6-bb73-24e1d3ea586c)
![2025-02-05 20 04 13 (4)](https://github.com/user-attachments/assets/e56f7fca-156c-4a31-82aa-00fc6eb90a8d)


## 💬 어려웠던 점

❌
