### PR TITLE
[#25] 로그인 api 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -34,7 +34,7 @@ dependencies {
 
 	// email authentication code send
 	implementation 'org.springframework.boot:spring-boot-starter-mail'
-	implementation 'org.springframework.data:spring-data-redis:2.7.5'
+	implementation 'org.springframework.boot:spring-boot-starter-data-redis'
 	implementation 'io.lettuce:lettuce-core:6.5.1.RELEASE'
 
 	// query dsl

--- a/src/main/java/com/flab/s_market/common/config/RedisConfig.java
+++ b/src/main/java/com/flab/s_market/common/config/RedisConfig.java
@@ -1,31 +1,33 @@
 package com.flab.s_market.common.config;
 
+import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.autoconfigure.data.redis.RedisProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.data.redis.connection.RedisConnectionFactory;
 import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.data.redis.repository.configuration.EnableRedisRepositories;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
 
 @Configuration
 @EnableRedisRepositories
+@RequiredArgsConstructor
 public class RedisConfig {
-    @Value("${spring.data.redis.host}")
-    private String redisHost;
-
-    @Value("${spring.data.redis.port}")
-    private int redisPort;
+    private final RedisProperties redisProperties;
 
     @Bean
     public RedisConnectionFactory redisConnectionFactory() {
-        return new LettuceConnectionFactory(redisHost, redisPort);
+        return new LettuceConnectionFactory(redisProperties.getHost(), redisProperties.getPort());
     }
 
     @Bean
     public RedisTemplate<?, ?> redisTemplate() {
-        RedisTemplate<byte[], byte[]> redisTemplate = new RedisTemplate<>();
-        redisTemplate.setConnectionFactory((redisConnectionFactory()));
+        RedisTemplate<String, Object> redisTemplate = new RedisTemplate<>();
+        redisTemplate.setConnectionFactory(redisConnectionFactory());
+        redisTemplate.setKeySerializer(new StringRedisSerializer());
+        redisTemplate.setValueSerializer(new StringRedisSerializer());
         return redisTemplate;
     }
 }

--- a/src/main/java/com/flab/s_market/common/exception/CustomException.java
+++ b/src/main/java/com/flab/s_market/common/exception/CustomException.java
@@ -12,11 +12,13 @@ public class CustomException extends RuntimeException{
     private final Consumer<String> logMethod;
     private final Exception exception;
     // ex. 외부 라이브러리에서 i/o exception 발생함 -> customException으로 예외 던짐 -> 원본 exception 추가해서 던져줌
-    public String getMessage(){
-        return errorCode.getMessage();
-    }
+
     public CustomException(ErrorCode errorCode, Map<String, Object> parameters, Consumer<String> logMethod){
         this(errorCode, parameters, logMethod, null);
+    }
+
+    public String getMessage(){
+        return errorCode.getExternalMessage();
     }
     public CustomException(ErrorCode errorCode, Map<String, Object> parameters, Consumer<String> logMethod, Exception exception){
         this.errorCode = errorCode;

--- a/src/main/java/com/flab/s_market/common/exception/ErrorCode.java
+++ b/src/main/java/com/flab/s_market/common/exception/ErrorCode.java
@@ -7,22 +7,25 @@ import org.springframework.http.HttpStatus;
 @Getter
 @AllArgsConstructor
 public enum ErrorCode {
-    EXIST_EMAIL("ACCOUNT-001", "이미 사용중인 이메일입니다. 다른 이메일을 작성해주세요.", HttpStatus.BAD_REQUEST),
-    NOT_VALID_EMAIL_CODE("ACCOUNT-002", "인증코드가 틀립니다. 이메일을 확인해주세요.", HttpStatus.NOT_FOUND),
-    NOT_VALID_PASSWORD("ACCOUNT-03", "비밀번호와 재확인 비밀번호가 다릅니다. 비밀번호를 다시 확인해주세요.", HttpStatus.BAD_REQUEST),
-    NOT_MATCH_TERM_VERSION("ACCOUNT-04", "약관 버전이 잘못 되었습니다. 약관 버전을 다시 확인해주세요.", HttpStatus.NOT_FOUND),
-    MAIL_SYSTEM_ERROR("ACCOUNT-05", "이메일 시스템 에러가 발생했습니다. 발송 이메일을 다시 확인해주세요.", HttpStatus.INTERNAL_SERVER_ERROR),
-    ENCRYPTION_FAILED("ACCOUNT-06", "이메일 암호화에 실패하였습니다. 다시 시도해주세요.", HttpStatus.INTERNAL_SERVER_ERROR),
-    DECRYPTION_FAILED("ACCOUNT-07", "이메일키 복호화에 실패하였습니다. 다시 시도해주세요.", HttpStatus.INTERNAL_SERVER_ERROR),
-    NOT_ALL_AGREED_REQUIRED_TERMS("ACCOUNT-08", "필수 약관에 모두 동의해야합니다.", HttpStatus.BAD_REQUEST),
-    NOT_PASSED_FIVE_MINUTES("ACCOUNT-09", "이메일에 인증코드를 발송한 지 5분이 지나지 않았습니다. 이메일을 확인해주세요.", HttpStatus.NOT_FOUND),
-    NOT_EXIST_TERM("ACCOUNT-10", "존재하지 않는 약관 이름 또는 약관 버전입니다. 약관 이름 또는 약관 버전을 확인해주세요.", HttpStatus.NOT_FOUND),
-    EXIST_USER("ACCOUNT-11", "이미 해당 계정은 회원가입되어있습니다. 이메일을 다시 확인해주세요.", HttpStatus.BAD_REQUEST),
-    INVALID_TOKEN("ACCOUNT-12", "잘못된 토큰을 전송하였습니다. 토큰 정보를 다시 확인해주세요.", HttpStatus.BAD_REQUEST),
-    EXPIRED_TOKEN("ACCOUNT-13", "토큰이 만료되었습니다. 새로운 토큰을 발급받아주세요.", HttpStatus.BAD_REQUEST);
+    EXIST_EMAIL("ACCOUNT-001", "이미 사용중인 이메일입니다. 다른 이메일을 작성해주세요.", "", HttpStatus.BAD_REQUEST),
+    NOT_VALID_EMAIL_CODE("ACCOUNT-002", "인증코드가 틀립니다. 이메일을 확인해주세요.", "", HttpStatus.NOT_FOUND),
+    NOT_VALID_PASSWORD("ACCOUNT-03", "비밀번호와 재확인 비밀번호가 다릅니다. 비밀번호를 다시 확인해주세요.", "", HttpStatus.BAD_REQUEST),
+    NOT_MATCH_TERM_VERSION("ACCOUNT-04", "약관 버전이 잘못 되었습니다. 약관 버전을 다시 확인해주세요.", "", HttpStatus.NOT_FOUND),
+    MAIL_SYSTEM_ERROR("ACCOUNT-05", "이메일 시스템 에러가 발생했습니다. 발송 이메일을 다시 확인해주세요.", "", HttpStatus.INTERNAL_SERVER_ERROR),
+    ENCRYPTION_FAILED("ACCOUNT-06", "이메일 암호화에 실패하였습니다. 다시 시도해주세요.", "", HttpStatus.INTERNAL_SERVER_ERROR),
+    DECRYPTION_FAILED("ACCOUNT-07", "이메일키 복호화에 실패하였습니다. 다시 시도해주세요.", "", HttpStatus.INTERNAL_SERVER_ERROR),
+    NOT_ALL_AGREED_REQUIRED_TERMS("ACCOUNT-08", "필수 약관에 모두 동의해야합니다.", "", HttpStatus.BAD_REQUEST),
+    NOT_PASSED_FIVE_MINUTES("ACCOUNT-09", "이메일에 인증코드를 발송한 지 5분이 지나지 않았습니다. 이메일을 확인해주세요.", "", HttpStatus.NOT_FOUND),
+    NOT_EXIST_TERM("ACCOUNT-10", "존재하지 않는 약관 이름 또는 약관 버전입니다. 약관 이름 또는 약관 버전을 확인해주세요.", "", HttpStatus.NOT_FOUND),
+    EXIST_USER("ACCOUNT-11", "이미 해당 계정은 회원가입되어있습니다. 이메일을 다시 확인해주세요.", "", HttpStatus.BAD_REQUEST),
+    INVALID_TOKEN("ACCOUNT-12", "잘못된 토큰을 전송하였습니다. 토큰 정보를 다시 확인해주세요.", "", HttpStatus.BAD_REQUEST),
+    EXPIRED_TOKEN("ACCOUNT-13", "토큰이 만료되었습니다. 새로운 토큰을 발급받아주세요.", "", HttpStatus.BAD_REQUEST),
+    ALREADY_LOGIN("ACCOUNT-14", "이미 로그인이 한 상태입니다. 로그인한 페이지로 돌아가주세요.", "", HttpStatus.NOT_FOUND),
+    NOT_EQUAL_REFRESH_TOKEN("ACCOUNT-15", "리프레시 토큰 정보가 일치하지 않습니다. 토큰 정보를 다시 확인해주세요", "", HttpStatus.BAD_REQUEST);
 
 
     private final String code;
-    private final String message;
+    private final String externalMessage;
+    private final String internalMessage;
     private final HttpStatus httpStatus;
 }

--- a/src/main/java/com/flab/s_market/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/flab/s_market/common/exception/GlobalExceptionHandler.java
@@ -16,6 +16,7 @@ import org.springframework.web.bind.annotation.RestControllerAdvice;
 @RestControllerAdvice
 public class GlobalExceptionHandler {
     private Logger log = LoggerFactory.getLogger(GlobalExceptionHandler.class);
+    // error response를 정확히 어떻게 바꿔야할지 고민중
     @Order(1)
     @ExceptionHandler(value={CustomException.class})
     public ResponseEntity<ApiResponse<?>> handleCustomException(CustomException e){
@@ -33,8 +34,7 @@ public class GlobalExceptionHandler {
         String errorMessage = ExceptionUtils.getFullStackTrace(e);
         log.error("ConstraintViolationException occured : getFullStackTrace - " + errorMessage);
 
-        return new ResponseEntity<>(ApiResponse.createFailWithErrorMessage(errorMessage),
-            HttpStatus.BAD_REQUEST);
+        return new ResponseEntity<>(ApiResponse.createFailWithErrorMessage(errorMessage), HttpStatus.BAD_REQUEST);
     }
 
     @Order(3)
@@ -51,7 +51,8 @@ public class GlobalExceptionHandler {
     public ResponseEntity<ApiResponse<?>> handleException(Exception e){
         String errorMessage = ExceptionUtils.getFullStackTrace(e);
         log.error("Exception occured : getFullStackTrace - " + errorMessage);
-        // 모든 예외에 대해 처리할때 httpStatus는 어떤걸로 지정해야할지 모르겠음
-        return new ResponseEntity<>(ApiResponse.createFailWithErrorMessage(errorMessage), HttpStatus.BAD_REQUEST);
+        // external error 어떻게 활용..??
+         // 9999
+        return new ResponseEntity<>(ApiResponse.createFailWithErrorMessage(errorMessage), HttpStatus.INTERNAL_SERVER_ERROR);
     }
 }

--- a/src/main/java/com/flab/s_market/domains/member/controller/v1/MemberController.java
+++ b/src/main/java/com/flab/s_market/domains/member/controller/v1/MemberController.java
@@ -7,6 +7,7 @@ import com.flab.s_market.domains.member.dto.request.JoinInfoDTO;
 import com.flab.s_market.domains.member.dto.request.LoginRequestDTO;
 import com.flab.s_market.domains.member.service.EmailService;
 import com.flab.s_market.domains.member.service.MemberService;
+import com.flab.s_market.domains.security.dto.request.JwtTokenReissueRequestDTO;
 import com.flab.s_market.domains.security.dto.response.JwtTokenResponseDTO;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.Pattern;
@@ -55,6 +56,12 @@ public class MemberController {
     @PostMapping("/login")
     public ApiResponse<JwtTokenResponseDTO> login(@RequestBody @Valid LoginRequestDTO dto){
         JwtTokenResponseDTO responseData = memberService.login(dto);
+        return ApiResponse.createSuccess(responseData);
+    }
+
+    @PostMapping("/reissue")
+    public ApiResponse<JwtTokenResponseDTO> reissue(@RequestBody @Valid JwtTokenReissueRequestDTO dto){
+        JwtTokenResponseDTO responseData = memberService.reissueToken(dto);
         return ApiResponse.createSuccess(responseData);
     }
 

--- a/src/main/java/com/flab/s_market/domains/member/service/MemberService.java
+++ b/src/main/java/com/flab/s_market/domains/member/service/MemberService.java
@@ -5,23 +5,26 @@ import com.flab.s_market.common.exception.CustomException;
 import com.flab.s_market.common.exception.ErrorCode;
 import com.flab.s_market.domains.member.domain.Member;
 import com.flab.s_market.domains.member.domain.MemberSubTermId;
+import com.flab.s_market.domains.member.dto.request.AgreedTermDTO;
+import com.flab.s_market.domains.member.dto.request.JoinInfoDTO;
 import com.flab.s_market.domains.member.dto.request.LoginRequestDTO;
-import com.flab.s_market.domains.security.service.JwtTokenProvider;
+import com.flab.s_market.domains.member.repository.MemberRepository;
+import com.flab.s_market.domains.member.repository.MemberSubTermRepository;
+import com.flab.s_market.domains.security.dto.request.JwtTokenReissueRequestDTO;
 import com.flab.s_market.domains.security.dto.response.JwtTokenResponseDTO;
+import com.flab.s_market.domains.security.service.JwtTokenProvider;
 import com.flab.s_market.domains.term.domain.SubTerm;
 import com.flab.s_market.domains.term.domain.Term;
 import com.flab.s_market.domains.term.repository.TermRepository;
-import com.flab.s_market.domains.member.dto.request.AgreedTermDTO;
-import com.flab.s_market.domains.member.dto.request.JoinInfoDTO;
-import com.flab.s_market.domains.member.repository.MemberRepository;
-import com.flab.s_market.domains.member.repository.MemberSubTermRepository;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.apache.commons.lang.ObjectUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.config.annotation.authentication.builders.AuthenticationManagerBuilder;
 import org.springframework.security.core.Authentication;
@@ -42,6 +45,10 @@ public class MemberService {
     private final BCryptPasswordEncoder bCryptPasswordEncoder;
     private final JwtTokenProvider jwtTokenProvider;
     private final AuthenticationManagerBuilder authenticationManagerBuilder;
+    private final RedisTemplate redisTemplate;
+    private static final long ACCESS_TOKEN_EXPIRE_TIME = 30*60*1000L; // 30분
+    private static final long REFRESH_TOKEN_EXPIRE_TIME = 7*24*60*60*1000L; // 7일
+    private static final String TOKEN_GRANT_TYPE = "Bearer";
 
     public void checkEmailDuplicated(String email) {
         if(userRepository.existsByEmail(email)){
@@ -75,6 +82,9 @@ public class MemberService {
         List<SubTerm> allTermsInDB = termRepository.findByTermIdAndVersionWithJoin();
 
         Member savedMember = userRepository.save(dto.toUserEntity(email, encPassword));
+        // stream 써서 required인 것과 아닌걸 나눠서 list만들어서 dataset을 만들어서 쓰면 이렇게 깊어지진 않음
+        // +++++ 중복되는건 메서드로 빼고 중간 결과를 list, set으로 만들게 되면 if 없어짐
+        // chatgpt plugin 써봐라
         for (SubTerm subTerm : allTermsInDB) {
             Term term = subTerm.getTerm();
             if(term.getIsRequired()){
@@ -128,8 +138,49 @@ public class MemberService {
         // authenticated값이 true
         Authentication authentication = authenticationManagerBuilder.getObject().authenticate(authenticationToken);
 
-        // 3. 인증 정보를 기반으로 JWT 토큰 생성
-        JwtTokenResponseDTO jwtToken = jwtTokenProvider.generateToken(authentication);
+        // 3. accessToken이 발급목록에 있는지 확인
+        if(Boolean.TRUE.equals(redisTemplate.hasKey("AT:" + email))){
+            throw new CustomException(ErrorCode.ALREADY_LOGIN, Map.of("dto", dto), log::info);
+        }
+
+        // 4. 인증 정보를 기반으로 JWT 토큰 생성
+        String accessToken = jwtTokenProvider.generateAccessToken(authentication);
+        String refreshToken = jwtTokenProvider.generateRefreshToken();
+        JwtTokenResponseDTO jwtToken = new JwtTokenResponseDTO(TOKEN_GRANT_TYPE, accessToken, refreshToken, ACCESS_TOKEN_EXPIRE_TIME, REFRESH_TOKEN_EXPIRE_TIME);
+
+        // 5. RefreshToken Redis 저장 (expirationTime 설정을 통해 자동 삭제 처리) + accesstoken이 발급한 목록이 있는지 확인
+        redisTemplate.opsForValue()
+                .set("AT:" + email, jwtToken.accessToken(), jwtToken.accessTokenExpirationTime(), TimeUnit.MILLISECONDS);
+        redisTemplate.opsForValue()
+            .set("RT:" + email, jwtToken.refreshToken(), jwtToken.refreshTokenExpirationTime(), TimeUnit.MILLISECONDS);
+
+        return jwtToken;
+    }
+
+    public JwtTokenResponseDTO reissueToken(JwtTokenReissueRequestDTO dto) {
+
+        // 1. Refresh Token 검증
+        jwtTokenProvider.validateToken(dto.refreshToken());
+
+        // 2. Refresh Token 에서 User email 를 가져옵니다.
+        Authentication authentication = jwtTokenProvider.getAuthentication(dto.accessToken());
+
+        // 3. Redis 에서 User email 을 기반으로 저장된 Refresh Token 값을 가져옵니다.
+        String refreshToken = (String)redisTemplate.opsForValue().get("RT:" + authentication.getName());
+        assert refreshToken != null;
+        if(!refreshToken.equals(dto.refreshToken())) {
+            throw new CustomException(ErrorCode.NOT_EQUAL_REFRESH_TOKEN, Map.of("refreshToken", refreshToken), log::info);
+        }
+
+        // 4. 새로운 토큰 생성
+        String accessToken = jwtTokenProvider.generateAccessToken(authentication);
+        JwtTokenResponseDTO jwtToken = new JwtTokenResponseDTO(
+            TOKEN_GRANT_TYPE, accessToken, refreshToken, ACCESS_TOKEN_EXPIRE_TIME, redisTemplate.getExpire("RT:"+authentication.getName())
+        );
+
+        // 5. RefreshToken Redis 업데이트
+        redisTemplate.opsForValue()
+            .set("AT:" + authentication.getName(), jwtToken.accessToken(), jwtToken.accessTokenExpirationTime(), TimeUnit.MILLISECONDS);
 
         return jwtToken;
     }

--- a/src/main/java/com/flab/s_market/domains/security/dto/request/JwtTokenReissueRequestDTO.java
+++ b/src/main/java/com/flab/s_market/domains/security/dto/request/JwtTokenReissueRequestDTO.java
@@ -1,0 +1,10 @@
+package com.flab.s_market.domains.security.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record JwtTokenReissueRequestDTO(
+    @NotBlank(message = "accessToken을 입력해주세요")
+    String accessToken,
+    @NotBlank(message = "refreshToken을 입력해주세요")
+    String refreshToken
+){ }

--- a/src/main/java/com/flab/s_market/domains/security/dto/response/JwtTokenResponseDTO.java
+++ b/src/main/java/com/flab/s_market/domains/security/dto/response/JwtTokenResponseDTO.java
@@ -3,5 +3,7 @@ package com.flab.s_market.domains.security.dto.response;
 public record JwtTokenResponseDTO(
     String grantType,
     String accessToken,
-    String refreshToken
+    String refreshToken,
+    Long accessTokenExpirationTime,
+    Long refreshTokenExpirationTime
 ){ }

--- a/src/main/java/com/flab/s_market/domains/security/service/JwtTokenProvider.java
+++ b/src/main/java/com/flab/s_market/domains/security/service/JwtTokenProvider.java
@@ -2,7 +2,6 @@ package com.flab.s_market.domains.security.service;
 
 import com.flab.s_market.common.exception.CustomException;
 import com.flab.s_market.common.exception.ErrorCode;
-import com.flab.s_market.domains.security.dto.response.JwtTokenResponseDTO;
 import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.ExpiredJwtException;
 import io.jsonwebtoken.Jwts;
@@ -33,7 +32,6 @@ import org.springframework.stereotype.Component;
 public class JwtTokenProvider {
     // JWT 서명을 위한 KEY 객체
     private final Key key;
-    private static final String TOKEN_GRANT_TYPE = "Bearer";
     private static final String HEADER_ALGORITHM = "HS256";
     private static final String HEADER_TYPE = "JWT";
     private static final String AUTHORITIES_KEY = "auth";
@@ -50,19 +48,21 @@ public class JwtTokenProvider {
     }
 
     // Member 정보를 가지고 AccessToken, RefreshToken을 생성하는 메서드
-    public JwtTokenResponseDTO generateToken(Authentication authentication) {
+
+    public String generateAccessToken(Authentication authentication){
         // 권한 가져오기
         String authorities = authentication.getAuthorities().stream()
             .map(GrantedAuthority::getAuthority)
             .collect(Collectors.joining(","));
 
-        // 현재 시간 가져오기
-        long now = (new Date()).getTime();
         // 토큰 발급 시간
         Date issueAt = new Date();
 
+        // 현재 시간 가져오기
+        long now = (new Date()).getTime();
+
         // access token 생성
-        String accessToken = Jwts.builder()
+        return Jwts.builder()
             .setHeader(createHeaders())
             .setSubject(authentication.getName()) // 토큰 주제 설정
             .claim(AUTHORITIES_KEY, authorities) // 사용자 권한 설정
@@ -70,15 +70,17 @@ public class JwtTokenProvider {
             .setIssuedAt(issueAt)
             .signWith(key, SignatureAlgorithm.HS256) // 서명 알고리즘 생성
             .compact();
+    }
 
-        // Refresh Token 생성
-        String refreshToken = Jwts.builder()
+    public String generateRefreshToken(){
+        // 현재 시간 가져오기
+        long now = (new Date()).getTime();
+
+        return Jwts.builder()
             .setHeader(createHeaders())
             .setExpiration(new Date(now + REFRESH_TOKEN_EXPIRE_TIME)) // 토큰 만료시간 설정(일주일)
             .signWith(key, SignatureAlgorithm.HS256) // 서명 알고리즘 생성
             .compact();
-
-        return new JwtTokenResponseDTO(TOKEN_GRANT_TYPE, accessToken, refreshToken);
     }
 
     private static Map<String, Object> createHeaders(){
@@ -92,9 +94,9 @@ public class JwtTokenProvider {
     }
 
     // Jwt 토큰을 복호화하여 토큰에 들어있는 정보를 꺼내, Authentication 객체를 생성하는 메서드
-    public Authentication getAuthentication(String accessToken) {
+    public Authentication getAuthentication(String token) {
         // Jwt 토큰 복호화
-        Claims claims = parseClaims(accessToken);
+        Claims claims = parseClaims(token);
 
         if (claims.get(AUTHORITIES_KEY) == null) {
             throw new RuntimeException("권한 정보가 없는 토큰입니다.");

--- a/src/test/java/com/flab/s_market/EmailTest.java
+++ b/src/test/java/com/flab/s_market/EmailTest.java
@@ -8,6 +8,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 
 @ExtendWith(SpringExtension.class)
@@ -18,6 +19,8 @@ public class EmailTest {
     @Autowired
     private EncryptionService encryptionService;
     private Logger log = LoggerFactory.getLogger(this.getClass().getSimpleName());
+    @Autowired
+    private BCryptPasswordEncoder encoder;
 
     @Test
     @DisplayName("Aes128 암호화가 잘 되는지 확인 테스트")
@@ -27,5 +30,13 @@ public class EmailTest {
         String dec = encryptionService.decrypt(enc);
         log.info("enc = {}", enc);
         log.info("dec = {}", dec);
+    }
+
+    @Test
+    public void bcryptPasswordEncoder(){
+        String password = "songhee12!";
+        String encPassword = encoder.encode(password);
+        boolean isMatch = encoder.matches(password, encPassword);
+        log.info("isMatch = {}", isMatch);
     }
 }


### PR DESCRIPTION
## #️⃣ 연관된 이슈

- #25 

## 📝 구현 기능 명세

- lettuceConnectionFactory 매개변수로 redisProperties 사용하도록 수정
- org.springframework.data 대신 org.springframework.boot에 있는 redis를 사용하도록 수정
- JwtTokenProvider : 한꺼번에 액세스토큰과 리프레시 토큰을 발급하는 것이 아닌 각각 따로 발급할 수 있도록 메서드 분리
- JwtTokenResponseDTO : 액세스 토큰없이 리프레시 토큰만으로는 Authentication을 확인할 방법이 없으므로 재발급 요청시 액세스 토큰과 리프레시 토큰을 받도록 수정
- JwtTokenResponseDTO : accessToken의 만료시간(남은 시간), 리프레시 토큰의 만료시간(남은 시간)도 함께 확인할 수 있도록 추가
- MemberController : 액세스 토큰 재발급 api를 위한 컨트롤러 추가
- MemberService :
  login() - 리프레시 토큰, 액세스 토큰 모두 레디스에 저장 및 TTL 설정
  reissueToken() - 액세스 토큰 만료시, 리프레시 토큰 검증 후 액세스 토큰만 새로 발급하도록 하여 레디스에 새로 등록
- CustomException : getMessage() - 서버에서 전달받고자하는 메세지를 반환하도록 수정
- ErrorCode : externalMessage, internalMessage 추가, 기존 ErrorCode 요소에 추가된 internalMessage는 ""로 일단 통일
- GlobalExceptionHandler : 클라이언트에게 어떤 메세지와 로그를 출력할지 다시 고민

### 📷 스크린샷 (선택)

❌

## 💬 어려웠던 점

❌
