### PR TITLE
[#29] 로그아웃 api 구현

### DIFF
--- a/src/main/java/com/flab/s_market/domains/member/controller/v1/MemberController.java
+++ b/src/main/java/com/flab/s_market/domains/member/controller/v1/MemberController.java
@@ -7,6 +7,7 @@ import com.flab.s_market.domains.member.dto.request.JoinInfoDTO;
 import com.flab.s_market.domains.member.dto.request.LoginRequestDTO;
 import com.flab.s_market.domains.member.service.EmailService;
 import com.flab.s_market.domains.member.service.MemberService;
+import com.flab.s_market.domains.security.dto.request.JwtTokenLogoutRequestDTO;
 import com.flab.s_market.domains.security.dto.request.JwtTokenReissueRequestDTO;
 import com.flab.s_market.domains.security.dto.response.JwtTokenResponseDTO;
 import jakarta.validation.Valid;
@@ -63,6 +64,11 @@ public class MemberController {
     public ApiResponse<JwtTokenResponseDTO> reissue(@RequestBody @Valid JwtTokenReissueRequestDTO dto){
         JwtTokenResponseDTO responseData = memberService.reissueToken(dto);
         return ApiResponse.createSuccess(responseData);
+    }
+
+    @PostMapping("/logout")
+    public void logout(@RequestBody @Valid JwtTokenLogoutRequestDTO dto){
+        memberService.logout(dto);
     }
 
 }

--- a/src/main/java/com/flab/s_market/domains/member/service/MemberService.java
+++ b/src/main/java/com/flab/s_market/domains/member/service/MemberService.java
@@ -10,6 +10,7 @@ import com.flab.s_market.domains.member.dto.request.JoinInfoDTO;
 import com.flab.s_market.domains.member.dto.request.LoginRequestDTO;
 import com.flab.s_market.domains.member.repository.MemberRepository;
 import com.flab.s_market.domains.member.repository.MemberSubTermRepository;
+import com.flab.s_market.domains.security.dto.request.JwtTokenLogoutRequestDTO;
 import com.flab.s_market.domains.security.dto.request.JwtTokenReissueRequestDTO;
 import com.flab.s_market.domains.security.dto.response.JwtTokenResponseDTO;
 import com.flab.s_market.domains.security.service.JwtTokenProvider;
@@ -166,10 +167,14 @@ public class MemberService {
         Authentication authentication = jwtTokenProvider.getAuthentication(dto.accessToken());
 
         // 3. Redis 에서 User email 을 기반으로 저장된 Refresh Token 값을 가져옵니다.
-        String refreshToken = (String)redisTemplate.opsForValue().get("RT:" + authentication.getName());
-        assert refreshToken != null;
-        if(!refreshToken.equals(dto.refreshToken())) {
-            throw new CustomException(ErrorCode.NOT_EQUAL_REFRESH_TOKEN, Map.of("refreshToken", refreshToken), log::info);
+        String refreshToken = "";
+        if(redisTemplate.hasKey("RT:" + authentication.getName())){
+            refreshToken = (String)redisTemplate.opsForValue().get("RT:" + authentication.getName());
+            if(!refreshToken.equals(dto.refreshToken())) {
+                throw new CustomException(ErrorCode.NOT_EQUAL_REFRESH_TOKEN, Map.of("refreshToken", refreshToken, "dto.refreshToken", dto.refreshToken()), log::info);
+            }
+        }else{
+            throw new CustomException(ErrorCode.EXPIRED_TOKEN, Map.of("refreshToken", refreshToken), log::info);
         }
 
         // 4. 새로운 토큰 생성
@@ -185,4 +190,15 @@ public class MemberService {
         return jwtToken;
     }
 
+    public void logout(JwtTokenLogoutRequestDTO dto) {
+        jwtTokenProvider.validateToken(dto.accessToken());
+
+        Authentication authentication = jwtTokenProvider.getAuthentication(dto.accessToken());
+        if(redisTemplate.hasKey("AT:"+authentication.getName())){
+            redisTemplate.delete("AT:"+authentication.getName());
+        }
+        if(redisTemplate.hasKey("RT:"+authentication.getName())){
+            redisTemplate.delete("RT:"+authentication.getName());
+        }
+    }
 }

--- a/src/main/java/com/flab/s_market/domains/security/dto/request/JwtTokenLogoutRequestDTO.java
+++ b/src/main/java/com/flab/s_market/domains/security/dto/request/JwtTokenLogoutRequestDTO.java
@@ -1,0 +1,10 @@
+package com.flab.s_market.domains.security.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record JwtTokenLogoutRequestDTO(
+    @NotBlank(message = "accessToken을 입력해주세요")
+    String accessToken
+) {
+
+}


### PR DESCRIPTION
## #️⃣ 연관된 이슈

- #29 

## 📝 구현 기능 명세

- request dto로 accessToken을 받도록 record class 추가
- 컨트롤러에 logout 메서드 추가
- 서비스단에 logout 메서드 추가 및 토큰 유효성 검증과 레디스 삭제 코드 추가

### 📷 스크린샷 (선택)

❌

## 💬 어려웠던 점

❌
