### PR TITLE
[#4, #5] 레디스 정보 저장시 키값 변화

### DIFF
--- a/src/main/java/com/flab/s_market/common/exception/ErrorCode.java
+++ b/src/main/java/com/flab/s_market/common/exception/ErrorCode.java
@@ -21,7 +21,8 @@ public enum ErrorCode {
     INVALID_TOKEN("ACCOUNT-12", "잘못된 토큰을 전송하였습니다. 토큰 정보를 다시 확인해주세요.", "", HttpStatus.BAD_REQUEST),
     EXPIRED_TOKEN("ACCOUNT-13", "토큰이 만료되었습니다. 새로운 토큰을 발급받아주세요.", "", HttpStatus.BAD_REQUEST),
     ALREADY_LOGIN("ACCOUNT-14", "이미 로그인이 한 상태입니다. 로그인한 페이지로 돌아가주세요.", "", HttpStatus.NOT_FOUND),
-    NOT_EQUAL_REFRESH_TOKEN("ACCOUNT-15", "리프레시 토큰 정보가 일치하지 않습니다. 토큰 정보를 다시 확인해주세요", "", HttpStatus.BAD_REQUEST);
+    NOT_EQUAL_REFRESH_TOKEN("ACCOUNT-15", "리프레시 토큰 정보가 일치하지 않습니다. 토큰 정보를 다시 확인해주세요", "", HttpStatus.BAD_REQUEST),
+    VERIFY_CODE("ACCOUNT-16", "이미 인증코드가 전송되었습니다. 인증코드를 작성해주세요.", "", HttpStatus.NOT_FOUND);
 
 
     private final String code;

--- a/src/main/java/com/flab/s_market/domains/member/service/EmailService.java
+++ b/src/main/java/com/flab/s_market/domains/member/service/EmailService.java
@@ -81,14 +81,17 @@ public class EmailService {
 
     // 메일 보내기
     public void sendEmail(String toEmail){
-        if (existEmailData(toEmail)) {
+        if (existEmailData("SE"+toEmail)) {
             throw new CustomException(ErrorCode.NOT_PASSED_FIVE_MINUTES, Map.of("email", toEmail), log::info);
+        }
+        if(existEmailData("VE"+toEmail)){
+            throw new CustomException(ErrorCode.VERIFY_CODE, Map.of("email", toEmail), log::info);
         }
 
         try {
             String authCode = createdCode();
             MimeMessage emailForm = createEmailForm(toEmail, authCode);
-            setDataWithTTL(toEmail, authCode, 60 * 5L);
+            setDataWithTTL("SE:"+toEmail, authCode, 60 * 5L);
             mailSender.send(emailForm);
         }catch(Exception e){
             throw new CustomException(ErrorCode.MAIL_SYSTEM_ERROR, Map.of("email", toEmail), log::warn, e); // i/o exception
@@ -99,14 +102,14 @@ public class EmailService {
     public String verifyEmailCode(EmailCodeDTO dto){
         String email = dto.email();
         String code = dto.code();
-        Optional<String> codeFoundByEmail = getEmailDataIfExist(dto.email());
+        Optional<String> codeFoundByEmail = getEmailDataIfExist("SE:"+dto.email());
         if (codeFoundByEmail.isEmpty()) {
             throw new CustomException(ErrorCode.NOT_VALID_EMAIL_CODE,
                 Map.of("email", email, "emailCode", code), log::info);
         }
-        deleteEmailData(email);
+        deleteEmailData("SE"+email);
         String emailKey = encryptionService.encrypt(email);
-        setDataWithTTL(email, emailKey, 60*30L);
+        setDataWithTTL("VE:"+email, emailKey, 60*30L);
 
         log.info("enc = {}", emailKey);
 


### PR DESCRIPTION
## #️⃣ 연관된 이슈

- #4 
- #5 

## 📝 구현 기능 명세

- 이메일로 인증코드를 보낼때의 value값과 이메일 인증코드를 검사할때의 value값이 레디스에서 다 구분을 해주어야하기 때문에, key값 저장시 인증코드 보낼경우 "SE", 인증코드 검사시 "VE"로 검사하도록 수정

### 📷 스크린샷 (선택)
❌

## 💬 어려웠던 점

❌
